### PR TITLE
Use trait to map FFI type

### DIFF
--- a/safer-ffi-gen/examples/basic_usage.rs
+++ b/safer-ffi-gen/examples/basic_usage.rs
@@ -8,6 +8,18 @@ pub struct TestStruct {
     private_string: String,
 }
 
+impl safer_ffi_gen::FfiType for TestStruct {
+    type Foreign = TestStruct;
+
+    fn from_foreign(x: Self::Foreign) -> Self {
+        x
+    }
+
+    fn to_foreign(self) -> Self::Foreign {
+        self
+    }
+}
+
 #[safer_ffi_gen]
 impl TestStruct {
     #[safer_ffi_gen_func]

--- a/safer-ffi-gen/src/lib.rs
+++ b/safer-ffi-gen/src/lib.rs
@@ -1,2 +1,112 @@
 pub use safer_ffi;
 pub use safer_ffi_gen_macro::*;
+
+pub trait FfiType {
+    type Foreign;
+
+    fn to_foreign(self) -> Self::Foreign;
+    fn from_foreign(x: Self::Foreign) -> Self;
+}
+
+macro_rules! impl_ffi_type_as_identity {
+    ($ty:ty) => {
+        impl FfiType for $ty {
+            type Foreign = $ty;
+
+            fn to_foreign(self) -> $ty {
+                self
+            }
+
+            fn from_foreign(x: $ty) -> $ty {
+                x
+            }
+        }
+    };
+}
+
+impl_ffi_type_as_identity!(i8);
+impl_ffi_type_as_identity!(u8);
+impl_ffi_type_as_identity!(i16);
+impl_ffi_type_as_identity!(u16);
+impl_ffi_type_as_identity!(i32);
+impl_ffi_type_as_identity!(u32);
+impl_ffi_type_as_identity!(i64);
+impl_ffi_type_as_identity!(u64);
+
+impl FfiType for bool {
+    type Foreign = u8;
+
+    fn to_foreign(self) -> Self::Foreign {
+        self as _
+    }
+
+    fn from_foreign(x: Self::Foreign) -> Self {
+        x != 0
+    }
+}
+
+impl FfiType for String {
+    type Foreign = safer_ffi::String;
+
+    fn to_foreign(self) -> Self::Foreign {
+        self.into()
+    }
+
+    fn from_foreign(x: Self::Foreign) -> Self {
+        x.into()
+    }
+}
+
+impl<T> FfiType for Vec<T> {
+    type Foreign = safer_ffi::Vec<T>;
+
+    fn to_foreign(self) -> Self::Foreign {
+        self.into()
+    }
+
+    fn from_foreign(x: Self::Foreign) -> Self {
+        x.into()
+    }
+}
+
+impl<T> FfiType for Box<T> {
+    type Foreign = safer_ffi::boxed::Box<T>;
+
+    fn to_foreign(self) -> Self::Foreign {
+        self.into()
+    }
+
+    fn from_foreign(x: Self::Foreign) -> Self {
+        x.into()
+    }
+}
+
+impl<'a, T> FfiType for &'a T
+where
+    T: FfiType<Foreign = T>,
+{
+    type Foreign = &'a T;
+
+    fn to_foreign(self) -> Self::Foreign {
+        self
+    }
+
+    fn from_foreign(x: Self::Foreign) -> Self {
+        x
+    }
+}
+
+impl<'a, T> FfiType for &'a mut T
+where
+    T: FfiType<Foreign = T>,
+{
+    type Foreign = &'a mut T;
+
+    fn to_foreign(self) -> Self::Foreign {
+        self
+    }
+
+    fn from_foreign(x: Self::Foreign) -> Self {
+        x
+    }
+}


### PR DESCRIPTION
Generated code for the example:
```rust
#[no_mangle]
pub extern "C" fn test_struct_new(
    vec_input: <Vec<u8> as ::safer_ffi_gen::FfiType>::Foreign,
    string_input: <String as ::safer_ffi_gen::FfiType>::Foreign,
) -> <TestStruct as ::safer_ffi_gen::FfiType>::Foreign {
    let vec_input = ::safer_ffi_gen::FfiType::from_foreign(vec_input);
    let string_input = ::safer_ffi_gen::FfiType::from_foreign(string_input);
    let res = TestStruct::new(vec_input, string_input);
    ::safer_ffi_gen::FfiType::to_foreign(res)
}

#[no_mangle]
pub extern "C" fn test_struct_do_something_with_string(
    this: <&TestStruct as ::safer_ffi_gen::FfiType>::Foreign,
    input: <String as ::safer_ffi_gen::FfiType>::Foreign,
) -> <String as ::safer_ffi_gen::FfiType>::Foreign {
    let this = ::safer_ffi_gen::FfiType::from_foreign(this);
    let input = ::safer_ffi_gen::FfiType::from_foreign(input);
    let res = TestStruct::do_something_with_string(this, input);
    ::safer_ffi_gen::FfiType::to_foreign(res)
}

#[no_mangle]
pub extern "C" fn test_struct_do_something_mut_with_string(
    this: <&mut TestStruct as ::safer_ffi_gen::FfiType>::Foreign,
    input: <String as ::safer_ffi_gen::FfiType>::Foreign,
) -> <String as ::safer_ffi_gen::FfiType>::Foreign {
    let this = ::safer_ffi_gen::FfiType::from_foreign(this);
    let input = ::safer_ffi_gen::FfiType::from_foreign(input);
    let res = TestStruct::do_something_mut_with_string(this, input);
    ::safer_ffi_gen::FfiType::to_foreign(res)
}
```

Resolves #8 