### PR TITLE
Support opaque types

### DIFF
--- a/safer-ffi-gen-macro/src/lib.rs
+++ b/safer-ffi-gen-macro/src/lib.rs
@@ -23,7 +23,7 @@ struct ReturnFFIType(Option<FFIType>);
 impl ToTokens for ReturnFFIType {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         match self.0.as_ref().map(|v| &v.native_type) {
-            Some(ty) => quote! { -> <#ty as ::safer_ffi_gen::FfiType>::Foreign },
+            Some(ty) => quote! { -> <#ty as ::safer_ffi_gen::FfiType>::Safe },
             None => quote! {},
         }
         .to_tokens(tokens)
@@ -42,7 +42,7 @@ impl ToTokens for FFIArgument {
         let ty = &self.ffi_type.native_type;
 
         quote! {
-           #name: <#ty as ::safer_ffi_gen::FfiType>::Foreign
+           #name: <#ty as ::safer_ffi_gen::FfiType>::Safe
         }
         .to_tokens(tokens)
     }
@@ -65,7 +65,7 @@ impl ToTokens for FFIArgumentConversion {
         let name = &self.ffi_arg.name;
 
         quote! {
-            let #name = ::safer_ffi_gen::FfiType::from_foreign(#name);
+            let #name = ::safer_ffi_gen::FfiType::from_safe(#name);
         }
         .to_tokens(tokens)
     }
@@ -170,7 +170,7 @@ impl ToTokens for FFIFunction {
         let input_names: Punctuated<Ident, Comma> =
             Punctuated::from_iter(self.parameters.iter().map(|arg| arg.name.clone()));
 
-        // TODO: Switch to safer_ffi::export_ffi
+        // TODO: Switch to safer_ffi::ffi_export
         quote! {
             #[no_mangle]
             pub extern "C" fn #ffi_function_name(#ffi_function_inputs) #ffi_function_output {
@@ -178,7 +178,7 @@ impl ToTokens for FFIFunction {
 
                 let res = #module_name::#function_name(#input_names);
 
-                ::safer_ffi_gen::FfiType::to_foreign(res)
+                ::safer_ffi_gen::FfiType::into_safe(res)
             }
         }
         .to_tokens(tokens);

--- a/safer-ffi-gen/examples/basic_usage.rs
+++ b/safer-ffi-gen/examples/basic_usage.rs
@@ -9,14 +9,14 @@ pub struct TestStruct {
 }
 
 impl safer_ffi_gen::FfiType for TestStruct {
-    type Foreign = TestStruct;
+    type Safe = safer_ffi::boxed::Box<TestStruct>;
 
-    fn from_foreign(x: Self::Foreign) -> Self {
-        x
+    fn from_safe(x: Self::Safe) -> Self {
+        *x.into()
     }
 
-    fn to_foreign(self) -> Self::Foreign {
-        self
+    fn into_safe(self) -> Self::Safe {
+        safer_ffi::boxed::Box::new(self)
     }
 }
 

--- a/safer-ffi-gen/src/lib.rs
+++ b/safer-ffi-gen/src/lib.rs
@@ -1,23 +1,25 @@
+use safer_ffi::layout::ReprC;
+
 pub use safer_ffi;
 pub use safer_ffi_gen_macro::*;
 
 pub trait FfiType {
-    type Foreign;
+    type Safe;
 
-    fn to_foreign(self) -> Self::Foreign;
-    fn from_foreign(x: Self::Foreign) -> Self;
+    fn into_safe(self) -> Self::Safe;
+    fn from_safe(x: Self::Safe) -> Self;
 }
 
 macro_rules! impl_ffi_type_as_identity {
     ($ty:ty) => {
         impl FfiType for $ty {
-            type Foreign = $ty;
+            type Safe = $ty;
 
-            fn to_foreign(self) -> $ty {
+            fn into_safe(self) -> $ty {
                 self
             }
 
-            fn from_foreign(x: $ty) -> $ty {
+            fn from_safe(x: $ty) -> $ty {
                 x
             }
         }
@@ -32,81 +34,64 @@ impl_ffi_type_as_identity!(i32);
 impl_ffi_type_as_identity!(u32);
 impl_ffi_type_as_identity!(i64);
 impl_ffi_type_as_identity!(u64);
-
-impl FfiType for bool {
-    type Foreign = u8;
-
-    fn to_foreign(self) -> Self::Foreign {
-        self as _
-    }
-
-    fn from_foreign(x: Self::Foreign) -> Self {
-        x != 0
-    }
-}
+impl_ffi_type_as_identity!(bool);
 
 impl FfiType for String {
-    type Foreign = safer_ffi::String;
+    type Safe = safer_ffi::String;
 
-    fn to_foreign(self) -> Self::Foreign {
+    fn into_safe(self) -> Self::Safe {
         self.into()
     }
 
-    fn from_foreign(x: Self::Foreign) -> Self {
+    fn from_safe(x: Self::Safe) -> Self {
         x.into()
     }
 }
 
-impl<T> FfiType for Vec<T> {
-    type Foreign = safer_ffi::Vec<T>;
+impl<T: ReprC> FfiType for Vec<T> {
+    type Safe = safer_ffi::Vec<T>;
 
-    fn to_foreign(self) -> Self::Foreign {
+    fn into_safe(self) -> Self::Safe {
         self.into()
     }
 
-    fn from_foreign(x: Self::Foreign) -> Self {
+    fn from_safe(x: Self::Safe) -> Self {
         x.into()
     }
 }
 
-impl<T> FfiType for Box<T> {
-    type Foreign = safer_ffi::boxed::Box<T>;
+impl<T: ReprC> FfiType for Box<T> {
+    type Safe = safer_ffi::boxed::Box<T>;
 
-    fn to_foreign(self) -> Self::Foreign {
+    fn into_safe(self) -> Self::Safe {
         self.into()
     }
 
-    fn from_foreign(x: Self::Foreign) -> Self {
+    fn from_safe(x: Self::Safe) -> Self {
         x.into()
     }
 }
 
-impl<'a, T> FfiType for &'a T
-where
-    T: FfiType<Foreign = T>,
-{
-    type Foreign = &'a T;
+impl<'a, T: ReprC> FfiType for &'a T {
+    type Safe = &'a T;
 
-    fn to_foreign(self) -> Self::Foreign {
+    fn into_safe(self) -> Self::Safe {
         self
     }
 
-    fn from_foreign(x: Self::Foreign) -> Self {
+    fn from_safe(x: Self::Safe) -> Self {
         x
     }
 }
 
-impl<'a, T> FfiType for &'a mut T
-where
-    T: FfiType<Foreign = T>,
-{
-    type Foreign = &'a mut T;
+impl<'a, T: ReprC> FfiType for &'a mut T {
+    type Safe = &'a mut T;
 
-    fn to_foreign(self) -> Self::Foreign {
+    fn into_safe(self) -> Self::Safe {
         self
     }
 
-    fn from_foreign(x: Self::Foreign) -> Self {
+    fn from_safe(x: Self::Safe) -> Self {
         x
     }
 }


### PR DESCRIPTION
`FfiType::Safe` now maps to the type safe for FFI according to `safer-ffi`, which is wrapped in `Box` for opaque types.

Bounds were changed in blanket implementations to reflect the fact that inner types just need to be `ReprC`.