### PR TITLE
Fix unit return type

### DIFF
--- a/safer-ffi-gen/src/lib.rs
+++ b/safer-ffi-gen/src/lib.rs
@@ -35,6 +35,7 @@ impl_ffi_type_as_identity!(u32);
 impl_ffi_type_as_identity!(i64);
 impl_ffi_type_as_identity!(u64);
 impl_ffi_type_as_identity!(bool);
+impl_ffi_type_as_identity!(());
 
 impl<'a> FfiType for &'a str {
     type Safe = safer_ffi::string::str_ref<'a>;

--- a/safer-ffi-gen/tests/unit_return_type.rs
+++ b/safer-ffi-gen/tests/unit_return_type.rs
@@ -1,0 +1,14 @@
+use safer_ffi_gen::{safer_ffi_gen, safer_ffi_gen_func};
+
+pub struct Foo;
+
+#[safer_ffi_gen]
+impl Foo {
+    #[safer_ffi_gen_func]
+    pub fn foo() {}
+}
+
+#[test]
+fn unit_return_type_works() {
+    foo_foo();
+}


### PR DESCRIPTION
I broke it when introducing the `FfiType` trait.