### PR TITLE
Handle `Self`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Cargo Build 
+name: Cargo Build
 on: [push, pull_request]
 jobs:
   BuildAndTest:
@@ -15,3 +15,5 @@ jobs:
       run: cargo clippy --all-targets --all-features --workspace -- -D warnings
     - name: Build Example
       run: cargo build --examples --features=tokio,tokio/time
+    - name: Test
+      run: cargo test --all-features --all-targets

--- a/safer-ffi-gen-macro/Cargo.toml
+++ b/safer-ffi-gen-macro/Cargo.toml
@@ -10,6 +10,6 @@ proc-macro = true
 proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["extra-traits", "full"] }
+syn = { version = "1", features = ["extra-traits", "fold", "full"] }
 convert_case = "0.6"
 

--- a/safer-ffi-gen/tests/self_type.rs
+++ b/safer-ffi-gen/tests/self_type.rs
@@ -1,0 +1,30 @@
+use safer_ffi_gen::{ffi_type, safer_ffi_gen, safer_ffi_gen_func};
+
+#[ffi_type(opaque)]
+pub struct Foo {
+    pub i: i32,
+}
+
+#[safer_ffi_gen]
+impl Foo {
+    #[safer_ffi_gen_func]
+    pub fn take_self_by_value(_x: Self) {}
+
+    #[safer_ffi_gen_func]
+    pub fn take_self_by_ref(_x: &Self) {}
+
+    #[safer_ffi_gen_func]
+    pub fn take_wrapped_self(_x: Vec<&Self>) {}
+
+    #[safer_ffi_gen_func]
+    pub fn return_self() -> Self {
+        Self { i: 33 }
+    }
+}
+
+#[test]
+fn self_type_works() {
+    foo_take_self_by_ref(&foo_return_self());
+    foo_take_self_by_value(foo_return_self());
+    foo_take_wrapped_self(vec![&*foo_return_self()].into());
+}


### PR DESCRIPTION
`Self` in methods needs to be replaced by the actual type in generated code (which is outside an `impl` block).