### PR TITLE
Expose function to clone opaque type instances

### DIFF
--- a/safer-ffi-gen/src/lib.rs
+++ b/safer-ffi-gen/src/lib.rs
@@ -6,6 +6,7 @@ pub use safer_ffi_gen_macro::*;
 #[cfg(feature = "tokio")]
 mod async_util;
 
+#[cfg(feature = "tokio")]
 pub use async_util::*;
 
 pub trait FfiType {

--- a/safer-ffi-gen/tests/clone.rs
+++ b/safer-ffi-gen/tests/clone.rs
@@ -1,0 +1,41 @@
+use safer_ffi_gen::{ffi_type, safer_ffi_gen, safer_ffi_gen_func};
+
+#[ffi_type(opaque, clone)]
+#[derive(Clone)]
+pub struct Foo {
+    i: i32,
+}
+
+#[safer_ffi_gen]
+impl Foo {
+    #[safer_ffi_gen_func]
+    pub fn new(i: i32) -> Foo {
+        Self { i }
+    }
+
+    #[safer_ffi_gen_func]
+    pub fn get(&self) -> i32 {
+        self.i
+    }
+
+    #[safer_ffi_gen_func]
+    pub fn inc(&mut self) {
+        self.i += 1;
+    }
+}
+
+#[test]
+fn cloning_works() {
+    let a = foo_new(33);
+    let b = foo_clone(&a);
+    assert_eq!(foo_get(&a), foo_get(&b));
+}
+
+#[test]
+fn cloning_returns_new_copy() {
+    let a = foo_new(33);
+    let mut b = foo_clone(&a);
+    foo_inc(&mut b);
+    assert_eq!(foo_get(&a), 33);
+    assert_eq!(foo_get(&b), 34);
+}


### PR DESCRIPTION
This is opt-in and requires the underlying type to implement `Clone`.

Resolves #20