### PR TITLE
Generic support

### DIFF
--- a/safer-ffi-gen-macro/Cargo.toml
+++ b/safer-ffi-gen-macro/Cargo.toml
@@ -7,9 +7,12 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
+convert_case = "0.6"
 proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["extra-traits", "fold", "full"] }
-convert_case = "0.6"
+syn = { version = "1", features = ["extra-traits", "fold", "full", "visit-mut"] }
+thiserror = "1.0.39"
 
+[dev-dependencies]
+assert2 = "0.3.10"

--- a/safer-ffi-gen-macro/src/error.rs
+++ b/safer-ffi-gen-macro/src/error.rs
@@ -1,0 +1,69 @@
+use proc_macro2::Span;
+use quote::ToTokens;
+use syn::spanned::Spanned;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("{reason}")]
+pub struct Error {
+    pub reason: ErrorReason,
+    pub span: Span,
+}
+
+impl Error {
+    pub fn new(span: Span, reason: ErrorReason) -> Self {
+        Self { reason, span }
+    }
+
+    pub fn new_spanned<T>(token: T, reason: ErrorReason) -> Self
+    where
+        T: ToTokens,
+    {
+        Self {
+            reason,
+            span: token.span(),
+        }
+    }
+}
+
+impl From<Error> for syn::Error {
+    fn from(e: Error) -> Self {
+        syn::Error::new(e.span, e.reason)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum ErrorReason {
+    #[error("Argument is unknown")]
+    UnknownArg,
+    #[error(
+        "`clone` is not supported on generic types with type or const parameters; it must be \
+specified with `safer_ffi_gen::specialize` instead"
+    )]
+    CloneOnGenericType,
+    #[error("`opaque` is required as an argument; only opaque types are supported")]
+    OpaqueRequired,
+    #[error("Trait implementation blocks are not supported")]
+    TraitImplBlock,
+    #[error("Implementation block must be for a type path (e.g. `some_module::some_type`")]
+    ImplBlockMustBeForTypePath,
+    #[error("Only functions can be exported")]
+    OnylFunctionsCanBeExported,
+    #[error("Exported functions can only be generic over lifetimes")]
+    GenericFunction,
+    #[error("Unsupported parameter pattern")]
+    UnsupportedParamPattern,
+}
+
+impl ErrorReason {
+    pub fn with_span(self, span: Span) -> Error {
+        Error::new(span, self)
+    }
+
+    pub fn spanned<T>(self, token: T) -> Error
+    where
+        T: ToTokens,
+    {
+        Error::new_spanned(token, self)
+    }
+}

--- a/safer-ffi-gen-macro/src/ffi_module.rs
+++ b/safer-ffi-gen-macro/src/ffi_module.rs
@@ -1,0 +1,153 @@
+use crate::{
+    has_only_lifetime_parameters, specialization::specialization_macro_ident, Error, ErrorReason,
+    FfiSignature,
+};
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use std::mem::take;
+use syn::{
+    parse::{Parse, ParseStream},
+    Attribute, GenericArgument, GenericParam, Generics, Ident, ImplItem, ImplItemConst,
+    ImplItemMacro, ImplItemType, ItemImpl, PathArguments, Signature, Type, TypePath,
+};
+
+#[derive(Debug)]
+pub struct FfiModule {
+    type_path: TypePath,
+    generics: Generics,
+    functions: Vec<FfiSignature>,
+}
+
+impl FfiModule {
+    pub fn new(impl_block: ItemImpl) -> Result<Self, Error> {
+        if let Some((_, trait_, _)) = impl_block.trait_ {
+            return Err(ErrorReason::TraitImplBlock.spanned(trait_));
+        }
+
+        let Type::Path(path) = &*impl_block.self_ty else {
+            return Err(ErrorReason::ImplBlockMustBeForTypePath.spanned(impl_block.self_ty));
+        };
+
+        // Find functions
+        let functions = impl_block
+            .items
+            .into_iter()
+            .filter_map(|item| match item {
+                ImplItem::Method(method) => exported(&method.attrs)
+                    .is_some()
+                    .then(|| FfiSignature::parse((*impl_block.self_ty).clone(), method.sig)),
+                ImplItem::Const(ImplItemConst { attrs, .. })
+                | ImplItem::Type(ImplItemType { attrs, .. })
+                | ImplItem::Macro(ImplItemMacro { attrs, .. }) => exported(&attrs)
+                    .map(|marker| Err(ErrorReason::OnylFunctionsCanBeExported.spanned(marker))),
+                _ => None,
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(FfiModule {
+            type_path: path.clone(),
+            generics: impl_block.generics,
+            functions,
+        })
+    }
+
+    pub fn specialize(&mut self, alias: &Ident, target: &TypePath) {
+        let replacements = type_parameters(&self.type_path)
+            .cloned()
+            .zip(type_parameters(target).cloned())
+            .collect();
+
+        self.functions
+            .iter_mut()
+            .for_each(|f| f.replace_types(&replacements));
+
+        self.type_path = TypePath {
+            qself: None,
+            path: alias.clone().into(),
+        };
+
+        self.generics.params = take(&mut self.generics.params)
+            .into_iter()
+            .filter(|p| matches!(p, GenericParam::Lifetime(_)))
+            .collect();
+    }
+
+    fn write_functions(&self, tokens: &mut TokenStream) {
+        self.functions.iter().for_each(|f| {
+            let mut f = f.clone();
+            f.add_generics(&self.generics);
+            f.prefix_with_type(&self.type_path);
+            f.to_tokens(tokens);
+        });
+    }
+
+    fn write_specialization_macro(&self, tokens: &mut TokenStream) {
+        let macro_name = specialization_macro_ident(&self.type_path);
+        let type_path = &self.type_path;
+        let functions = self.functions.iter().cloned().map(Signature::from);
+        let (impl_generics, _, where_clause) = self.generics.split_for_impl();
+
+        let mini_impl_block = quote! {
+            impl #impl_generics  #type_path #where_clause {
+                #(
+                    #[safer_ffi_gen_func]
+                    #functions {}
+                )*
+            }
+        };
+
+        quote! {
+            macro_rules! #macro_name {
+                ($alias:ident = $ty:ty) => {
+                    ::safer_ffi_gen::__specialize!($alias, $ty, #mini_impl_block);
+                };
+            }
+        }
+        .to_tokens(tokens)
+    }
+}
+
+impl ToTokens for FfiModule {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        if has_only_lifetime_parameters(&self.generics) {
+            self.write_functions(tokens)
+        } else {
+            self.write_specialization_macro(tokens)
+        }
+    }
+}
+
+impl Parse for FfiModule {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let impl_block = ItemImpl::parse(input)?;
+        FfiModule::new(impl_block).map_err(Into::into)
+    }
+}
+
+fn exported(attrs: &[Attribute]) -> Option<&Ident> {
+    const EXPORT_MARKER: &str = "safer_ffi_gen_func";
+
+    attrs.iter().find_map(|attr| {
+        attr.path
+            .get_ident()
+            .filter(|&ident| ident == EXPORT_MARKER)
+    })
+}
+
+fn type_parameters(type_path: &TypePath) -> impl Iterator<Item = &Type> {
+    type_path
+        .path
+        .segments
+        .last()
+        .and_then(|segment| match &segment.arguments {
+            PathArguments::AngleBracketed(args) => {
+                Some(args.args.iter().filter_map(|arg| match arg {
+                    GenericArgument::Type(ty) => Some(ty),
+                    _ => None,
+                }))
+            }
+            _ => None,
+        })
+        .into_iter()
+        .flatten()
+}

--- a/safer-ffi-gen-macro/src/ffi_signature.rs
+++ b/safer-ffi-gen-macro/src/ffi_signature.rs
@@ -1,0 +1,557 @@
+use crate::{type_path_last_ident, Error, ErrorReason};
+use convert_case::{Case, Casing};
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+use std::{collections::HashMap, fmt::Display};
+use syn::{
+    token::SelfType, visit_mut::VisitMut, AngleBracketedGenericArguments, FnArg, GenericArgument,
+    GenericParam, Generics, Ident, Lifetime, LifetimeDef, Pat, PatIdent, PatType, PathArguments,
+    PathSegment, PredicateLifetime, QSelf, Receiver, ReturnType, Signature, Type, TypePath,
+    TypeReference, WhereClause, WherePredicate,
+};
+
+#[derive(Clone, Debug)]
+pub struct FfiSignature {
+    self_type: Type,
+    is_async: bool,
+    name: Ident,
+    lifetime_params: Vec<LifetimeDef>,
+    lifetime_predicates: Vec<PredicateLifetime>,
+    params: Vec<(Ident, Type)>,
+    return_type: ReturnType,
+    export_prefix: Option<String>,
+}
+
+impl FfiSignature {
+    pub fn parse(self_type: Type, signature: Signature) -> Result<FfiSignature, Error> {
+        let lifetime_params = signature
+            .generics
+            .params
+            .iter()
+            .map(|p| match p {
+                GenericParam::Lifetime(l) => Ok(l.clone()),
+                _ => Err(ErrorReason::GenericFunction.spanned(p)),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let lifetime_predicates =
+            filter_lifetime_predicates(signature.generics.where_clause.as_ref())
+                .cloned()
+                .collect();
+
+        let params = signature
+            .inputs
+            .into_iter()
+            .map(|input| match input {
+                FnArg::Receiver(Receiver {
+                    reference,
+                    mutability,
+                    ..
+                }) => Ok((
+                    self_param_name(),
+                    reference
+                        .map(|(and_token, lifetime)| {
+                            Type::Reference(TypeReference {
+                                and_token,
+                                lifetime,
+                                mutability,
+                                elem: Box::new(self_type.clone()),
+                            })
+                        })
+                        .unwrap_or_else(|| self_type.clone()),
+                )),
+                FnArg::Typed(PatType { pat, ty, .. }) => match *pat {
+                    Pat::Ident(pat) => Ok((pat.ident, *ty)),
+                    pat => Err(ErrorReason::UnsupportedParamPattern.spanned(pat)),
+                },
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut sig = FfiSignature {
+            self_type: self_type.clone(),
+            is_async: signature.asyncness.is_some(),
+            name: signature.ident,
+            lifetime_params,
+            lifetime_predicates,
+            params,
+            return_type: signature.output,
+            export_prefix: None,
+        };
+
+        sig.replace_types(&self_type_replacement(self_type));
+        Ok(sig)
+    }
+
+    pub fn prefix_with_type(&mut self, type_path: &TypePath) {
+        self.prefix_name(
+            type_path_last_ident(type_path)
+                .to_string()
+                .to_case(Case::Snake),
+        );
+    }
+
+    fn prefix_name<T: Display>(&mut self, prefix: T) {
+        self.export_prefix = Some(prefix.to_string());
+    }
+
+    pub fn add_generics(&mut self, generics: &Generics) {
+        self.lifetime_params.extend(generics.lifetimes().cloned());
+        self.lifetime_predicates
+            .extend(filter_lifetime_predicates(generics.where_clause.as_ref()).cloned());
+    }
+
+    pub fn replace_types(&mut self, replacements: &HashMap<Type, Type>) {
+        replace_types(&mut self.self_type, replacements);
+
+        self.params
+            .iter_mut()
+            .for_each(|(_, ty)| replace_types(ty, replacements));
+
+        if let ReturnType::Type(_, ty) = &mut self.return_type {
+            replace_types(ty, replacements);
+        }
+    }
+
+    fn make_result_output_parameter(&mut self) {
+        let ReturnType::Type(arrow, return_type) = &self.return_type else {
+            return;
+        };
+
+        let Some(ok_type) = result_ok_type(return_type) else {
+            return;
+        };
+
+        if !type_is_unit(ok_type) {
+            self.params
+                .push((output_param_name(), wrap_output_param_type(ok_type.clone())));
+        }
+
+        self.return_type = ReturnType::Type(
+            *arrow,
+            Box::new(Type::Path(TypePath {
+                qself: None,
+                path: string_to_path(true, "std::ffi::c_int"),
+            })),
+        );
+    }
+
+    fn make_types_ffi_safe(&mut self) {
+        let output_param = output_param_name();
+
+        self.params
+            .iter_mut()
+            .filter(|(name, _)| *name != output_param)
+            .for_each(|(_, ty)| {
+                *ty = make_type_ffi_safe(ty.clone());
+            });
+
+        if let ReturnType::Type(_, ty) = &mut self.return_type {
+            *ty = Box::new(make_type_ffi_safe((**ty).clone()));
+        }
+    }
+
+    fn export(&mut self) {
+        self.is_async = false;
+        self.make_result_output_parameter();
+        self.make_types_ffi_safe();
+    }
+}
+
+impl ToTokens for FfiSignature {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let mut adapted_sig = self.clone();
+        adapted_sig.export();
+        let signature = Signature::from(adapted_sig);
+
+        let arg_conversions = self.params.iter().map(|(name, _)| {
+            quote! {
+                let #name = ::safer_ffi_gen::FfiType::from_safe(#name);
+            }
+        });
+
+        let fn_name = &self.name;
+        let inputs = self.params.iter().map(|(name, _)| name);
+        let return_value = return_value_name();
+        let self_type = &self.self_type;
+
+        let call = quote! {
+            <#self_type>::#fn_name(#(#inputs,)*)
+        };
+
+        let call = if self.is_async {
+            quote! {
+                ::safer_ffi_gen::BLOCKING_ASYNC_RUNTIME.block_on(#call)
+            }
+        } else {
+            call
+        };
+
+        let return_expression = match &self.return_type {
+            ReturnType::Default => None,
+            ReturnType::Type(_, ty) => Some(match result_ok_type(ty) {
+                Some(ok_type) => {
+                    let set_output_param = (!type_is_unit(ok_type)).then(|| {
+                        let out_param = output_param_name();
+                        quote! {
+                            let ret = ::safer_ffi_gen::FfiType::into_safe(ret);
+                            #out_param.write(ret);
+                        }
+                    });
+
+                    quote! {
+                        match #return_value {
+                            Ok(ret) => {
+                                #set_output_param
+                                0
+                            }
+                            Err(e) => {
+                                ::safer_ffi_gen::set_last_error(e);
+                                -1
+                            }
+                        }
+                    }
+                }
+                None => quote! {
+                    ::safer_ffi_gen::FfiType::into_safe(#return_value)
+                },
+            }),
+        };
+
+        quote! {
+            #[::safer_ffi_gen::safer_ffi::ffi_export]
+            #signature {
+                #(#arg_conversions)*
+
+                let #return_value = #call;
+
+                #return_expression
+            }
+        }
+        .to_tokens(tokens);
+    }
+}
+
+impl From<FfiSignature> for Signature {
+    fn from(signature: FfiSignature) -> Self {
+        let has_lifetime = !signature.lifetime_params.is_empty();
+
+        Signature {
+            constness: None,
+            asyncness: signature.is_async.then(Default::default),
+            unsafety: None,
+            abi: None,
+            fn_token: Default::default(),
+            ident: Ident::new(
+                &format!(
+                    "{}{}",
+                    signature
+                        .export_prefix
+                        .as_ref()
+                        .map(|p| format!("{p}_"))
+                        .unwrap_or_default(),
+                    signature.name
+                ),
+                Span::call_site(),
+            ),
+            generics: Generics {
+                lt_token: has_lifetime.then(Default::default),
+                params: signature
+                    .lifetime_params
+                    .into_iter()
+                    .map(GenericParam::Lifetime)
+                    .collect(),
+                gt_token: has_lifetime.then(Default::default),
+                where_clause: (!signature.lifetime_predicates.is_empty()).then(|| WhereClause {
+                    where_token: Default::default(),
+                    predicates: signature
+                        .lifetime_predicates
+                        .into_iter()
+                        .map(WherePredicate::Lifetime)
+                        .collect(),
+                }),
+            },
+            paren_token: Default::default(),
+            inputs: signature
+                .params
+                .into_iter()
+                .map(|(name, ty)| {
+                    FnArg::Typed(PatType {
+                        attrs: Vec::new(),
+                        pat: Box::new(
+                            PatIdent {
+                                attrs: Vec::new(),
+                                by_ref: None,
+                                mutability: None,
+                                ident: name,
+                                subpat: None,
+                            }
+                            .into(),
+                        ),
+                        colon_token: Default::default(),
+                        ty: Box::new(ty),
+                    })
+                })
+                .collect(),
+            variadic: None,
+            output: signature.return_type,
+        }
+    }
+}
+
+fn filter_lifetime_predicates(
+    where_clause: Option<&WhereClause>,
+) -> impl Iterator<Item = &PredicateLifetime> {
+    where_clause
+        .into_iter()
+        .flat_map(|w| &w.predicates)
+        .filter_map(|pred| match pred {
+            WherePredicate::Lifetime(l) => Some(l),
+            _ => None,
+        })
+}
+
+fn literally_self_type() -> Type {
+    Type::Path(TypePath {
+        qself: None,
+        path: SelfType {
+            span: Span::call_site(),
+        }
+        .into(),
+    })
+}
+
+fn self_type_replacement(self_type: Type) -> HashMap<Type, Type> {
+    [(literally_self_type(), self_type)].into_iter().collect()
+}
+
+fn replace_types(ty: &mut Type, replacements: &HashMap<Type, Type>) {
+    TypeReplacer { replacements }.visit_type_mut(ty)
+}
+
+#[derive(Debug)]
+struct TypeReplacer<'a> {
+    replacements: &'a HashMap<Type, Type>,
+}
+
+impl VisitMut for TypeReplacer<'_> {
+    fn visit_type_mut(&mut self, ty: &mut Type) {
+        if let Some(new_ty) = self.replacements.get(ty).cloned() {
+            *ty = new_ty;
+        }
+        syn::visit_mut::visit_type_mut(self, ty);
+    }
+}
+
+fn result_ok_type(ty: &Type) -> Option<&Type> {
+    let Type::Path(path) = ty else {
+        return None;
+    };
+
+    let result = path
+        .path
+        .segments
+        .last()
+        .filter(|segment| segment.ident == "Result")?;
+
+    let PathArguments::AngleBracketed(args) = &result.arguments else {
+        return None;
+    };
+
+    args.args.iter().find_map(|arg| match arg {
+        GenericArgument::Type(ty) => Some(ty),
+        _ => None,
+    })
+}
+
+fn type_is_unit(ty: &Type) -> bool {
+    matches!(ty, Type::Tuple(tuple) if tuple.elems.is_empty())
+}
+
+fn make_type_ffi_safe(ty: Type) -> Type {
+    const TARGET_PATH: &str = "safer_ffi_gen::FfiType::Safe";
+
+    Type::Path(TypePath {
+        qself: Some(QSelf {
+            lt_token: Default::default(),
+            ty: Box::new(ty),
+            position: TARGET_PATH.split("::").count() - 1,
+            as_token: Some(Default::default()),
+            gt_token: Default::default(),
+        }),
+        path: string_to_path(true, TARGET_PATH),
+    })
+}
+
+fn string_to_path(leading_colons: bool, segments: &str) -> syn::Path {
+    syn::Path {
+        leading_colon: leading_colons.then(Default::default),
+        segments: string_to_path_segments(segments).collect(),
+    }
+}
+
+fn string_to_path_segments(segments: &str) -> impl Iterator<Item = PathSegment> + '_ {
+    segments
+        .split("::")
+        .map(|s| PathSegment::from(Ident::new(s, Span::call_site())))
+}
+
+fn wrap_output_param_type(ty: Type) -> Type {
+    Type::Path(TypePath {
+        qself: None,
+        path: syn::Path {
+            leading_colon: Some(Default::default()),
+            segments: string_to_path_segments("safer_ffi_gen::safer_ffi::prelude")
+                .chain(Some(PathSegment {
+                    ident: Ident::new("Out", Span::call_site()),
+                    arguments: PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                        colon2_token: None,
+                        lt_token: Default::default(),
+                        args: [
+                            GenericArgument::Lifetime(Lifetime::new("'_", Span::call_site())),
+                            GenericArgument::Type(make_type_ffi_safe(ty)),
+                        ]
+                        .into_iter()
+                        .collect(),
+                        gt_token: Default::default(),
+                    }),
+                }))
+                .collect(),
+        },
+    })
+}
+
+fn self_param_name() -> Ident {
+    const SELF_PARAM_NAME: &str = "__safer_ffi_gen_self";
+    Ident::new(SELF_PARAM_NAME, Span::call_site())
+}
+
+fn output_param_name() -> Ident {
+    const OUTPUT_PARAM_NAME: &str = "__safer_ffi_gen_out";
+    Ident::new(OUTPUT_PARAM_NAME, Span::call_site())
+}
+
+fn return_value_name() -> Ident {
+    const RETURN_VALUE_NAME: &str = "__safer_ffi_gen_ret";
+    Ident::new(RETURN_VALUE_NAME, Span::call_site())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        ffi_signature::{
+            output_param_name, replace_types, result_ok_type, type_is_unit, FfiSignature,
+        },
+        test_utils::Pretty,
+    };
+    use assert2::assert;
+    use syn::{parse_quote, Signature, Type};
+
+    #[test]
+    fn unit_type_is_recognized() {
+        let ty: Type = parse_quote! { () };
+        assert!(type_is_unit(&ty));
+    }
+
+    #[test]
+    fn non_unit_type_is_recognized() {
+        let ty: Type = parse_quote! { Foo };
+        assert!(!type_is_unit(&ty));
+    }
+
+    #[test]
+    fn extracting_ok_type_from_result_works() {
+        let expected_ok_type: Type = parse_quote! { Success };
+        let result_type: Type = parse_quote! { Result<#expected_ok_type, Failure> };
+        let ok_type = result_ok_type(&result_type);
+        assert!(ok_type == Some(&expected_ok_type));
+    }
+
+    #[test]
+    fn extracting_ok_type_from_qualified_result_works() {
+        let expected_ok_type: Type = parse_quote! { Success };
+        let result_type: Type = parse_quote! { ::std::result::Result<#expected_ok_type, Failure> };
+        let ok_type = result_ok_type(&result_type);
+        assert!(ok_type == Some(&expected_ok_type));
+    }
+
+    #[test]
+    fn extracting_ok_type_from_non_result_returns_none() {
+        let ty: Type = parse_quote! { Foo };
+        assert!(result_ok_type(&ty) == None);
+    }
+
+    #[test]
+    fn replacing_single_type_works() {
+        let old_ty: Type = parse_quote! { Foo };
+        let new_ty: Type = parse_quote! { Bar };
+        let mut ty = old_ty.clone();
+        replace_types(&mut ty, &[(old_ty, new_ty.clone())].into_iter().collect());
+        assert!(ty == new_ty);
+    }
+
+    #[test]
+    fn replacing_multiple_types_works() {
+        let (foo, bar): (Type, Type) = (parse_quote! { Foo }, parse_quote! { Bar });
+        let (baz, quux): (Type, Type) = (parse_quote! { Baz }, parse_quote! { Quux });
+        let mut ty: Type = parse_quote! { (#foo, #bar) };
+        let expected: Type = parse_quote! { (#baz, #quux) };
+        replace_types(&mut ty, &[(foo, baz), (bar, quux)].into_iter().collect());
+        assert!(ty == expected);
+    }
+
+    #[test]
+    fn replacing_type_in_type_param_works() {
+        let old_type: Type = parse_quote! { Foo };
+        let new_type: Type = parse_quote! { Bar };
+        let mut ty: Type = parse_quote! { Vec<Foo> };
+        let expected: Type = parse_quote! { Vec<Bar> };
+        replace_types(&mut ty, &[(old_type, new_type)].into_iter().collect());
+        assert!(ty == expected);
+    }
+
+    #[test]
+    fn prefixing_function_name_works() {
+        let mut signature =
+            FfiSignature::parse(parse_quote! { FooBar }, parse_quote! { fn baz() }).unwrap();
+
+        signature.prefix_with_type(&parse_quote! { ::test::FooBar });
+        let expected_signature: Signature = parse_quote! { fn foo_bar_baz() };
+        let actual_signature = Signature::from(signature);
+        assert!(actual_signature == expected_signature);
+    }
+
+    #[test]
+    fn making_result_an_output_parameter_works() {
+        let mut signature = FfiSignature::parse(
+            parse_quote! { Foo },
+            parse_quote! { fn bar() -> Result<Bar, Error> },
+        )
+        .unwrap();
+
+        signature.make_result_output_parameter();
+        let output_param = output_param_name();
+
+        let expected_signature: Signature = parse_quote! {
+            fn bar(
+                #output_param: ::safer_ffi_gen::safer_ffi::prelude::Out<'_, <Bar as ::safer_ffi_gen::FfiType>::Safe>
+            ) -> ::std::ffi::c_int
+        };
+
+        let actual_signature = Signature::from(signature);
+        assert!(Pretty(actual_signature) == Pretty(expected_signature));
+    }
+
+    #[test]
+    fn unit_ok_type_does_not_cause_an_output_parameter() {
+        let mut signature = FfiSignature::parse(
+            parse_quote! { Foo },
+            parse_quote! { fn bar() -> Result<(), Error> },
+        )
+        .unwrap();
+
+        signature.make_result_output_parameter();
+        let expected_signature: Signature = parse_quote! { fn bar() -> ::std::ffi::c_int };
+        let actual_signature = Signature::from(signature);
+        assert!(actual_signature == expected_signature);
+    }
+}

--- a/safer-ffi-gen-macro/src/ffi_type.rs
+++ b/safer-ffi-gen-macro/src/ffi_type.rs
@@ -1,0 +1,165 @@
+use crate::{has_only_lifetime_parameters, Error, ErrorReason};
+use convert_case::{Case, Casing};
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+use syn::{AttributeArgs, Generics, Ident, ItemStruct, Meta, NestedMeta, Visibility};
+
+pub fn process_ffi_type(args: AttributeArgs, type_def: ItemStruct) -> Result<FfiTypeOutput, Error> {
+    let has_only_lifetime_params = has_only_lifetime_parameters(&type_def.generics);
+
+    let args = args
+        .iter()
+        .try_fold(FfiTypeArgs::default(), |mut acc, arg| match arg {
+            NestedMeta::Meta(Meta::Path(p)) => {
+                match &*p.get_ident().map(ToString::to_string).unwrap_or_default() {
+                    "opaque" => {
+                        acc.opaque = true;
+                        Ok(acc)
+                    }
+                    "clone" if has_only_lifetime_params => {
+                        acc.clone = true;
+                        Ok(acc)
+                    }
+                    "clone" => Err(ErrorReason::CloneOnGenericType.spanned(p)),
+                    _ => Err(ErrorReason::UnknownArg.spanned(p)),
+                }
+            }
+            _ => Err(ErrorReason::UnknownArg.spanned(arg)),
+        })?;
+
+    args.opaque
+        .then_some(())
+        .ok_or_else(|| ErrorReason::OpaqueRequired.with_span(Span::call_site()))?;
+
+    Ok(FfiTypeOutput {
+        type_def,
+        clone: args.clone,
+    })
+}
+
+#[derive(Debug, Default)]
+struct FfiTypeArgs {
+    opaque: bool,
+    clone: bool,
+}
+
+#[derive(Debug)]
+pub struct FfiTypeOutput {
+    type_def: ItemStruct,
+    clone: bool,
+}
+
+impl ToTokens for FfiTypeOutput {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let has_only_lifetime_params = has_only_lifetime_parameters(&self.type_def.generics);
+        let (impl_generics, type_generics, where_clause) = self.type_def.generics.split_for_impl();
+        let drop_fn = has_only_lifetime_params.then(|| {
+            export_drop(
+                &self.type_def.ident,
+                &self.type_def.vis,
+                &self.type_def.generics,
+            )
+        });
+        let clone_fn = self.clone.then(|| {
+            export_clone(
+                &self.type_def.ident,
+                &self.type_def.vis,
+                &self.type_def.generics,
+            )
+        });
+        let type_def = &self.type_def;
+        let ty = &self.type_def.ident;
+
+        let out = quote! {
+            #[::safer_ffi_gen::safer_ffi::derive_ReprC]
+            #[ReprC::opaque]
+            #type_def
+
+            impl #impl_generics ::safer_ffi_gen::FfiType for #ty #type_generics #where_clause {
+                type Safe = ::safer_ffi_gen::safer_ffi::boxed::Box<#ty #type_generics>;
+
+                fn into_safe(self) -> Self::Safe {
+                    ::safer_ffi_gen::safer_ffi::boxed::Box::new(self)
+                }
+
+                fn from_safe(x: Self::Safe) -> Self {
+                    *x.into()
+                }
+            }
+
+            #drop_fn
+
+            #clone_fn
+        };
+        out.to_tokens(tokens);
+    }
+}
+
+fn export_clone(ty: &Ident, type_visibility: &Visibility, generics: &Generics) -> TokenStream {
+    let prefix = fn_prefix(ty);
+    let clone_ident = Ident::new(&format!("{prefix}_clone"), Span::call_site());
+    let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        #[::safer_ffi_gen::safer_ffi::ffi_export]
+        #type_visibility fn #clone_ident #impl_generics(
+            x: <&#ty #type_generics as ::safer_ffi_gen::FfiType>::Safe,
+        ) -> <#ty #type_generics as ::safer_ffi_gen::FfiType>::Safe #where_clause {
+            ::safer_ffi_gen::safer_ffi::boxed::Box::new(::std::clone::Clone::clone(x))
+        }
+    }
+}
+
+fn export_drop(ty: &Ident, type_visibility: &Visibility, generics: &Generics) -> TokenStream {
+    let prefix = fn_prefix(ty);
+    let drop_ident = Ident::new(&format!("{prefix}_free"), Span::call_site());
+    let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        #[::safer_ffi_gen::safer_ffi::ffi_export]
+        #type_visibility fn #drop_ident #impl_generics(
+            x: <#ty #type_generics as ::safer_ffi_gen::FfiType>::Safe,
+        ) #where_clause {
+            ::core::mem::drop(x);
+        }
+    }
+}
+
+fn fn_prefix(ty: &Ident) -> String {
+    ty.to_string().to_case(Case::Snake)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{process_ffi_type, Error, ErrorReason};
+    use assert2::assert;
+    use syn::parse_quote;
+
+    #[test]
+    fn unknown_arg_to_ffi_type_fails() {
+        let res = process_ffi_type(
+            vec![parse_quote! { foobar }],
+            parse_quote! { struct Foo {} },
+        );
+        assert!(let Err(Error { reason: ErrorReason::UnknownArg, .. }) = res);
+    }
+
+    #[test]
+    fn clone_for_type_generic_over_type_fails() {
+        let res = process_ffi_type(
+            vec![parse_quote! { clone }],
+            parse_quote! { struct Foo<T> { x: T } },
+        );
+        assert!(let Err(Error { reason: ErrorReason::CloneOnGenericType, .. }) = res);
+    }
+
+    #[test]
+    fn clone_for_type_generic_over_lifetime_fails() {
+        let out = process_ffi_type(
+            vec![parse_quote! { opaque }, parse_quote! { clone }],
+            parse_quote! { struct Foo<'a> { s: &'a str } },
+        )
+        .unwrap();
+        assert!(out.clone);
+    }
+}

--- a/safer-ffi-gen-macro/src/lib.rs
+++ b/safer-ffi-gen-macro/src/lib.rs
@@ -1,423 +1,20 @@
-use convert_case::{Case, Casing};
-use proc_macro2::{Ident, Span, TokenStream};
-use quote::{format_ident, quote, ToTokens};
-use syn::{
-    fold::Fold, parse::Parse, punctuated::Punctuated, token::Comma, Attribute, AttributeArgs,
-    FnArg, GenericArgument, ImplItem, ImplItemMethod, ItemImpl, Meta, NestedMeta, Pat,
-    PathArguments, PathSegment, ReturnType, Type, TypePath, TypeReference,
-};
+use proc_macro2::{Ident, Span};
+use quote::ToTokens;
+use syn::{parse_macro_input, spanned::Spanned, AttributeArgs, GenericParam, Generics, TypePath};
 
-const EXPORT_MARKER: &str = "safer_ffi_gen_func";
+mod error;
+mod ffi_module;
+mod ffi_signature;
+mod ffi_type;
+mod specialization;
+#[cfg(test)]
+mod test_utils;
 
-#[derive(Debug, Clone)]
-struct FFIType {
-    native_type: Type,
-}
-
-impl FFIType {
-    fn new(native_type: Type, self_ty: Type) -> Self {
-        Self {
-            native_type: resolve_self(native_type, self_ty),
-        }
-    }
-
-    fn new_no_self(native_type: Type) -> Self {
-        Self { native_type }
-    }
-}
-
-struct SelfResolver(Type);
-
-impl Fold for SelfResolver {
-    fn fold_type(&mut self, i: Type) -> Type {
-        match &i {
-            Type::Path(p) => p
-                .path
-                .segments
-                .first()
-                .filter(|segment| p.path.segments.len() == 1 && segment.ident == "Self")
-                .map(|_| self.0.clone())
-                .unwrap_or_else(|| syn::fold::fold_type(self, i)),
-            _ => syn::fold::fold_type(self, i),
-        }
-    }
-}
-
-fn resolve_self(ty: Type, self_ty: Type) -> Type {
-    SelfResolver(self_ty).fold_type(ty)
-}
-
-#[derive(Debug)]
-struct ReturnFFIType(Option<FFIType>);
-
-impl ReturnFFIType {
-    fn last_path_segment(&self) -> Option<&PathSegment> {
-        self.0
-            .as_ref()
-            .and_then(|ffi_type| match ffi_type.native_type {
-                Type::Path(ref path) => path.path.segments.last(),
-                _ => None,
-            })
-            .filter(|last_path| last_path.ident.to_string().as_str() == "Result")
-    }
-
-    fn is_result(&self) -> bool {
-        self.last_path_segment().is_some()
-    }
-
-    fn out_arg(&self) -> Option<FFIArgument> {
-        self.last_path_segment().and_then(|ffi_type| {
-            let name = Ident::new("out", Span::call_site());
-
-            let PathArguments::AngleBracketed(ref args) = ffi_type.arguments else {
-                return None;
-            };
-
-            let Some(GenericArgument::Type(out_type)) = args.args.first() else {
-                return None;
-            };
-
-            if let Type::Tuple(tuple) = out_type {
-                if tuple.elems.is_empty() {
-                    return None;
-                }
-            }
-
-            Some(FFIArgument {
-                name,
-                ffi_type: FFIType::new_no_self(out_type.clone()),
-                is_out: true,
-            })
-        })
-    }
-}
-
-impl ToTokens for ReturnFFIType {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        if self.is_result() {
-            return quote! { -> ::std::os::raw::c_int }.to_tokens(tokens);
-        }
-
-        match self.0.as_ref().map(|v| &v.native_type) {
-            Some(ty) => quote! { -> <#ty as ::safer_ffi_gen::FfiType>::Safe },
-            None => quote! {},
-        }
-        .to_tokens(tokens)
-    }
-}
-
-#[derive(Debug, Clone)]
-struct FFIArgument {
-    name: Ident,
-    ffi_type: FFIType,
-    is_out: bool,
-}
-
-impl ToTokens for FFIArgument {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let name = &self.name;
-        let ty = &self.ffi_type.native_type;
-
-        if self.is_out {
-            quote! {
-                #name: ::safer_ffi::prelude::Out<'_, <#ty as ::safer_ffi_gen::FfiType>::Safe>
-            }
-        } else {
-            quote! {
-               #name: <#ty as ::safer_ffi_gen::FfiType>::Safe
-            }
-        }
-        .to_tokens(tokens)
-    }
-}
-
-#[derive(Debug)]
-#[non_exhaustive]
-struct FFIArgumentConversion {
-    ffi_arg: FFIArgument,
-}
-
-impl FFIArgumentConversion {
-    fn new(ffi_arg: FFIArgument) -> FFIArgumentConversion {
-        FFIArgumentConversion { ffi_arg }
-    }
-}
-
-impl ToTokens for FFIArgumentConversion {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let name = &self.ffi_arg.name;
-
-        quote! {
-            let #name = ::safer_ffi_gen::FfiType::from_safe(#name);
-        }
-        .to_tokens(tokens)
-    }
-}
-
-fn arg_to_ffi(module_name: &TypePath, arg: FnArg) -> syn::Result<FFIArgument> {
-    match arg {
-        FnArg::Receiver(rec) => {
-            let ty = Type::Path(module_name.clone());
-            let ty = match rec.reference {
-                Some((and_token, lifetime)) => Type::Reference(TypeReference {
-                    and_token,
-                    lifetime,
-                    mutability: rec.mutability,
-                    elem: ty.into(),
-                }),
-                None => ty,
-            };
-
-            Ok(FFIArgument {
-                name: Ident::new("this", Span::call_site()),
-                ffi_type: FFIType::new(ty, Type::Path(module_name.clone())),
-                is_out: false,
-            })
-        }
-        FnArg::Typed(pat_type) => {
-            let Pat::Ident(ident) = &*pat_type.pat else {
-                return Err(syn::Error::new_spanned(&*pat_type.pat, "Expected an identifier"));
-            };
-
-            Ok(FFIArgument {
-                name: ident.ident.clone(),
-                ffi_type: FFIType::new((*pat_type.ty).clone(), Type::Path(module_name.clone())),
-                is_out: false,
-            })
-        }
-    }
-}
-
-#[derive(Debug)]
-struct FFIFunction {
-    module_name: TypePath,
-    function_name: Ident,
-    parameters: Punctuated<FFIArgument, Comma>,
-    output: ReturnFFIType,
-    is_async: bool,
-}
-
-impl FFIFunction {
-    fn new(module_name: TypePath, method: ImplItemMethod) -> syn::Result<Self> {
-        let mut parameters = method
-            .sig
-            .inputs
-            .into_iter()
-            .map(|arg| arg_to_ffi(&module_name, arg))
-            .collect::<Result<Punctuated<FFIArgument, Comma>, _>>()?;
-
-        let output = match method.sig.output {
-            ReturnType::Default => ReturnFFIType(None),
-            ReturnType::Type(_, otype) => {
-                ReturnFFIType(Some(FFIType::new(*otype, Type::Path(module_name.clone()))))
-            }
-        };
-
-        if let Some(out_arg) = output.out_arg() {
-            parameters.push(out_arg);
-        }
-
-        Ok(Self {
-            module_name,
-            function_name: method.sig.ident,
-            parameters,
-            output,
-            is_async: method.sig.asyncness.is_some(),
-        })
-    }
-
-    fn ffi_function_name(&self) -> Ident {
-        format_ident!(
-            "{}_{}",
-            self.module_name
-                .to_token_stream()
-                .to_string()
-                .to_case(Case::Snake),
-            self.function_name
-        )
-    }
-
-    fn convert_output_with_result(&self) -> TokenStream {
-        let module_name = &self.module_name;
-
-        let handle_success = if self.output.out_arg().is_some() {
-            quote! {
-                out.write(::safer_ffi_gen::FfiType::into_safe(output));
-                0
-            }
-        } else {
-            quote! {0}
-        };
-
-        let handle_error = quote! {
-            #module_name::set_last_error(err);
-            -1
-        };
-
-        quote! {
-            match res {
-                Ok(output) => {
-                    #handle_success
-                }
-                Err(err) => {
-                    #handle_error
-                },
-            }
-        }
-    }
-
-    fn convert_output_no_result(&self) -> TokenStream {
-        quote! {
-            ::safer_ffi_gen::FfiType::into_safe(res)
-        }
-    }
-
-    fn convert_output(&self) -> TokenStream {
-        if self.output.is_result() {
-            self.convert_output_with_result()
-        } else {
-            self.convert_output_no_result()
-        }
-    }
-
-    fn method_impl_async_blocking(
-        &self,
-        module_name: &TypePath,
-        function_name: &Ident,
-        input_names: &Punctuated<Ident, Comma>,
-    ) -> TokenStream {
-        quote! {
-            let res = safer_ffi_gen::BLOCKING_ASYNC_RUNTIME
-                .block_on(#module_name::#function_name(#input_names));
-        }
-    }
-
-    fn method_impl_sync(
-        &self,
-        module_name: &TypePath,
-        function_name: &Ident,
-        input_names: &Punctuated<Ident, Comma>,
-    ) -> TokenStream {
-        quote! {
-            let res = #module_name::#function_name(#input_names);
-        }
-    }
-
-    fn method_impl(&self) -> TokenStream {
-        let module_name = &self.module_name;
-        let function_name = &self.function_name;
-
-        let input_names: Punctuated<Ident, Comma> = Punctuated::from_iter(
-            self.parameters
-                .iter()
-                .filter(|arg| !arg.is_out)
-                .map(|arg| arg.name.clone()),
-        );
-
-        if self.is_async {
-            self.method_impl_async_blocking(module_name, function_name, &input_names)
-        } else {
-            self.method_impl_sync(module_name, function_name, &input_names)
-        }
-    }
-}
-
-impl ToTokens for FFIFunction {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let ffi_function_name = self.ffi_function_name();
-        let ffi_function_inputs = &self.parameters;
-        let ffi_function_output = &self.output;
-
-        let type_conversions = self
-            .parameters
-            .iter()
-            .filter(|arg| !arg.is_out)
-            .cloned()
-            .map(FFIArgumentConversion::new);
-
-        let method_impl = self.method_impl();
-        let convert_output = self.convert_output();
-
-        quote! {
-            #[::safer_ffi_gen::safer_ffi::ffi_export]
-            pub fn #ffi_function_name(#ffi_function_inputs) #ffi_function_output {
-                #(#type_conversions)*
-
-                #method_impl
-                #convert_output
-            }
-        }
-        .to_tokens(tokens)
-    }
-}
-
-#[derive(Debug)]
-struct FFIModule {
-    functions: Vec<FFIFunction>,
-}
-
-impl FFIModule {
-    pub fn new(impl_block: ItemImpl) -> syn::Result<Self> {
-        if let Some((_, trait_, _)) = impl_block.trait_ {
-            return Err(syn::Error::new_spanned(
-                trait_,
-                "safer_ffi_gen does not support trait implementations",
-            ));
-        }
-
-        let Type::Path(path) = &*impl_block.self_ty else {
-            return Err(syn::Error::new_spanned(
-                &impl_block.self_ty,
-                "impl block must be for a type path",
-            ));
-        };
-
-        // Find functions
-        let functions = impl_block
-            .items
-            .into_iter()
-            .filter_map(|item| match item {
-                ImplItem::Method(method) => exported(&method.attrs)
-                    .is_some()
-                    .then(|| FFIFunction::new(path.clone(), method)),
-                ImplItem::Const(syn::ImplItemConst { attrs, .. })
-                | ImplItem::Type(syn::ImplItemType { attrs, .. })
-                | ImplItem::Macro(syn::ImplItemMacro { attrs, .. }) => {
-                    exported(&attrs).map(|marker| {
-                        Err(syn::Error::new_spanned(
-                            marker,
-                            "Only functions can be exported by safer_ffi_gen",
-                        ))
-                    })
-                }
-                _ => None,
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(FFIModule { functions })
-    }
-}
-
-impl ToTokens for FFIModule {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        self.functions.iter().for_each(|f| f.to_tokens(tokens))
-    }
-}
-
-impl Parse for FFIModule {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let impl_block = input.parse::<ItemImpl>()?;
-        FFIModule::new(impl_block)
-    }
-}
-
-fn exported(attrs: &[Attribute]) -> Option<&Ident> {
-    attrs.iter().find_map(|attr| {
-        attr.path
-            .get_ident()
-            .filter(|&ident| ident == EXPORT_MARKER)
-    })
-}
+use error::{Error, ErrorReason};
+use ffi_module::FfiModule;
+use ffi_signature::FfiSignature;
+use ffi_type::process_ffi_type;
+use specialization::{Specialization, SpecializationDecl};
 
 #[proc_macro_attribute]
 pub fn safer_ffi_gen(
@@ -426,7 +23,7 @@ pub fn safer_ffi_gen(
 ) -> proc_macro::TokenStream {
     let mut result = proc_macro2::TokenStream::from(item.clone());
 
-    let output = syn::parse_macro_input!(item as FFIModule);
+    let output = parse_macro_input!(item as FfiModule);
 
     // Add the output to the input
     output.to_tokens(&mut result);
@@ -449,111 +46,45 @@ pub fn ffi_type(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let args = syn::parse_macro_input!(args as AttributeArgs);
-    let ty_def = syn::parse_macro_input!(input as syn::ItemStruct);
+    let args = parse_macro_input!(args as AttributeArgs);
+    let ty_def = parse_macro_input!(input as syn::ItemStruct);
 
     process_ffi_type(args, ty_def)
+        .map(ToTokens::into_token_stream)
+        .map_err(Into::into)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }
 
-fn process_ffi_type(
-    args: AttributeArgs,
-    ty_def: syn::ItemStruct,
-) -> Result<proc_macro2::TokenStream, syn::Error> {
-    let args = args
-        .into_iter()
-        .try_fold(FfiTypeArgs::default(), |mut acc, arg| match arg {
-            NestedMeta::Meta(Meta::Path(p)) => {
-                match &*p.get_ident().map(ToString::to_string).unwrap_or_default() {
-                    "opaque" => {
-                        acc.opaque = true;
-                        Ok(acc)
-                    }
-                    "clone" => {
-                        acc.clone = true;
-                        Ok(acc)
-                    }
-                    _ => Err(syn::Error::new_spanned(p, "Unknown argument")),
-                }
-            }
-            _ => Err(syn::Error::new_spanned(arg, "Unknown argument")),
-        })?;
-
-    args.opaque.then_some(()).ok_or_else(|| {
-        syn::Error::new(
-            Span::call_site(),
-            "`opaque` must be specified as argument to `ffi_type`",
-        )
-    })?;
-
-    let ty = &ty_def.ident;
-    let ty_visibility = &ty_def.vis;
-    let ty_prefix = ty.to_string().to_case(Case::Snake);
-    let drop_ident = Ident::new(&format!("{ty_prefix}_free"), Span::call_site());
-
-    let clone_fn = args.clone.then(|| {
-        let clone_ident = Ident::new(&format!("{ty_prefix}_clone"), Span::call_site());
-
-        quote! {
-            #[::safer_ffi_gen::safer_ffi::ffi_export]
-            #ty_visibility fn #clone_ident(
-                x: <&#ty as ::safer_ffi_gen::FfiType>::Safe,
-            ) -> <#ty as ::safer_ffi_gen::FfiType>::Safe {
-                ::safer_ffi_gen::safer_ffi::boxed::Box::new(::std::clone::Clone::clone(x))
-            }
-        }
-    });
-
-    let last_error_ident = Ident::new(&format!("{ty_prefix}_last_error"), Span::call_site());
-
-    Ok(quote! {
-        #[::safer_ffi_gen::safer_ffi::derive_ReprC]
-        #[ReprC::opaque]
-        #ty_def
-
-        impl ::safer_ffi_gen::FfiType for #ty {
-            type Safe = ::safer_ffi_gen::safer_ffi::boxed::Box<#ty>;
-
-            fn into_safe(self) -> Self::Safe {
-                ::safer_ffi_gen::safer_ffi::boxed::Box::new(self)
-            }
-
-            fn from_safe(x: Self::Safe) -> Self {
-                *x.into()
-            }
-        }
-
-        #[::safer_ffi_gen::safer_ffi::ffi_export]
-        #ty_visibility fn #drop_ident(x: <#ty as ::safer_ffi_gen::FfiType>::Safe) {
-            ::core::mem::drop(x);
-        }
-
-        #clone_fn
-
-        #[::safer_ffi_gen::safer_ffi::ffi_export]
-        #ty_visibility fn #last_error_ident() -> Option<::safer_ffi::prelude::repr_c::String> {
-            #ty::LAST_ERROR.with(|prev| {
-                (*prev.borrow())
-                .as_ref()
-                .map(|err| ::safer_ffi::prelude::repr_c::String::from(err.to_string()))
-            })
-        }
-
-        impl #ty {
-            thread_local! {
-                static LAST_ERROR: ::std::cell::RefCell<Option<Box<dyn std::error::Error>>> = ::std::cell::RefCell::new(None);
-            }
-
-            pub(crate) fn set_last_error<E: std::error::Error + 'static>(err: E) {
-                Self::LAST_ERROR.with(|prev| *prev.borrow_mut() = Some(Box::new(err)))
-            }
-        }
-    })
+#[proc_macro]
+pub fn specialize(args: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let decl = parse_macro_input!(args as SpecializationDecl);
+    decl.to_token_stream().into()
 }
 
-#[derive(Debug, Default)]
-struct FfiTypeArgs {
-    opaque: bool,
-    clone: bool,
+#[doc(hidden)]
+#[proc_macro]
+pub fn __specialize(args: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let specialization = parse_macro_input!(args as Specialization);
+    specialization.to_token_stream().into()
+}
+
+fn type_path_last_ident(p: &TypePath) -> &Ident {
+    &p.path
+        .segments
+        .last()
+        .expect("Path has at least one segment")
+        .ident
+}
+
+fn has_only_lifetime_parameters(generics: &Generics) -> bool {
+    non_lifetime_parameter(generics).is_none()
+}
+
+fn non_lifetime_parameter(generics: &Generics) -> Option<Span> {
+    generics.params.iter().find_map(|p| match p {
+        GenericParam::Const(p) => Some(p.span()),
+        GenericParam::Type(p) => Some(p.span()),
+        GenericParam::Lifetime(_) => None,
+    })
 }

--- a/safer-ffi-gen-macro/src/specialization.rs
+++ b/safer-ffi-gen-macro/src/specialization.rs
@@ -1,0 +1,78 @@
+use crate::{type_path_last_ident, FfiModule};
+use convert_case::{Case, Casing};
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+use syn::{
+    parse::{Parse, ParseStream},
+    Ident, TypePath,
+};
+
+#[derive(Debug)]
+pub struct SpecializationDecl {
+    alias: Ident,
+    target: TypePath,
+}
+
+impl Parse for SpecializationDecl {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let alias = Ident::parse(input)?;
+        let _ = syn::token::Eq::parse(input)?;
+        let target = TypePath::parse(input)?;
+        Ok(Self { alias, target })
+    }
+}
+
+impl ToTokens for SpecializationDecl {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let mut macro_path = self.target.path.clone();
+
+        let last_segment = macro_path
+            .segments
+            .last_mut()
+            .expect("Path must have at least one segment");
+        *last_segment = specialization_macro_ident(&self.target).into();
+
+        let alias = &self.alias;
+        let target = &self.target;
+
+        quote! {
+            #macro_path! { #alias = #target }
+        }
+        .to_tokens(tokens)
+    }
+}
+
+pub fn specialization_macro_ident(type_path: &TypePath) -> Ident {
+    Ident::new(
+        &format!(
+            "__safer_ffi_gen_specialize_{}",
+            type_path_last_ident(type_path)
+                .to_string()
+                .to_case(Case::Snake),
+        ),
+        Span::call_site(),
+    )
+}
+
+#[derive(Debug)]
+pub struct Specialization {
+    mini_impl_block: FfiModule,
+}
+
+impl Parse for Specialization {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let alias = Ident::parse(input)?;
+        let _ = syn::token::Comma::parse(input)?;
+        let target = TypePath::parse(input)?;
+        let _ = syn::token::Comma::parse(input)?;
+        let mut mini_impl_block = FfiModule::parse(input)?;
+        mini_impl_block.specialize(&alias, &target);
+        Ok(Self { mini_impl_block })
+    }
+}
+
+impl ToTokens for Specialization {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.mini_impl_block.to_tokens(tokens);
+    }
+}

--- a/safer-ffi-gen-macro/src/test_utils.rs
+++ b/safer-ffi-gen-macro/src/test_utils.rs
@@ -1,0 +1,15 @@
+use quote::ToTokens;
+use std::fmt::{self, Debug};
+
+/// Helper to show syntax items as tokens, making it easier to inspect and spot differences
+#[derive(Eq, PartialEq)]
+pub struct Pretty<T>(pub T);
+
+impl<T> Debug for Pretty<T>
+where
+    T: ToTokens,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0.to_token_stream().to_string())
+    }
+}

--- a/safer-ffi-gen/examples/basic_usage.rs
+++ b/safer-ffi-gen/examples/basic_usage.rs
@@ -79,11 +79,9 @@ pub fn main() {
 
     assert_eq!(test_struct_do_something_that_fails(&test_struct), -1);
 
-    let err = test_struct_last_error();
+    let err: String = ::safer_ffi_gen::last_error().into();
 
-    assert!(err.is_some());
-
-    println!("Got error {:?}", err.unwrap());
+    println!("Got error {}", err);
 
     let async_res = test_struct_do_something_async(&test_struct);
     assert_eq!(async_res, 42);

--- a/safer-ffi-gen/src/lib.rs
+++ b/safer-ffi-gen/src/lib.rs
@@ -1,4 +1,5 @@
 use safer_ffi::layout::ReprC;
+use std::cell::RefCell;
 
 pub use safer_ffi;
 pub use safer_ffi_gen_macro::*;
@@ -115,7 +116,7 @@ impl<T: ReprC> FfiType for Box<T> {
     }
 }
 
-impl<T: ReprC> FfiType for Option<T>
+impl<T> FfiType for Option<T>
 where
     Option<T>: ReprC,
 {
@@ -152,4 +153,27 @@ impl<'a, T: ReprC> FfiType for &'a mut T {
     fn from_safe(x: Self::Safe) -> Self {
         x
     }
+}
+
+thread_local! {
+    static LAST_ERROR: RefCell<Option<Box<dyn std::error::Error>>> = RefCell::new(None);
+}
+
+pub fn set_last_error<E>(e: E)
+where
+    E: Into<Box<dyn std::error::Error>>,
+{
+    LAST_ERROR.with(|last_error| *last_error.borrow_mut() = Some(e.into()));
+}
+
+#[safer_ffi::ffi_export]
+pub fn last_error() -> safer_ffi::String {
+    LAST_ERROR
+        .with(|e| {
+            e.borrow()
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_default()
+        })
+        .into()
 }

--- a/safer-ffi-gen/tests/generic.rs
+++ b/safer-ffi-gen/tests/generic.rs
@@ -1,0 +1,27 @@
+use safer_ffi_gen::{ffi_type, safer_ffi_gen, safer_ffi_gen_func};
+
+#[ffi_type(opaque)]
+pub struct Foo<T> {
+    x: T,
+}
+
+#[safer_ffi_gen]
+impl<T> Foo<T> {
+    #[safer_ffi_gen_func]
+    pub fn new(x: T) -> Self {
+        Self { x }
+    }
+
+    #[safer_ffi_gen_func]
+    pub fn get(&self) -> &T {
+        &self.x
+    }
+}
+
+safer_ffi_gen::specialize! { FooI32 = Foo<i32> }
+
+#[test]
+fn specialization_works() {
+    let x = foo_i_32_new(33);
+    assert_eq!(*foo_i_32_get(&x), 33);
+}


### PR DESCRIPTION
    Support generic specialization

    Additional changes:
    - Improve error handling:
      - Do not panic in proc-macro on invalid input.
      - Return meaningful errors pointing to the issue in the source code.
    - Add unit tests.
    - Use full paths in generated code, and access `safer_ffi` through `safer_ffi_gen`.
    - `Option<safer_ffi::String>` is not FFI-safe so just use string for last error.
    - Store last error per thread instead of per thread and per exported type.

    Specialization only works in the module containing the `impl` block for now.