### PR TITLE
Replace `convert_case` with `heck`

### DIFF
--- a/safer-ffi-gen-macro/Cargo.toml
+++ b/safer-ffi-gen-macro/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-convert_case = "0.6"
+heck = "0.4.1"
 proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"

--- a/safer-ffi-gen-macro/src/ffi_signature.rs
+++ b/safer-ffi-gen-macro/src/ffi_signature.rs
@@ -1,5 +1,5 @@
 use crate::{type_path_last_ident, Error, ErrorReason};
-use convert_case::{Case, Casing};
+use heck::ToSnakeCase;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::{collections::HashMap, fmt::Display};
@@ -83,11 +83,7 @@ impl FfiSignature {
     }
 
     pub fn prefix_with_type(&mut self, type_path: &TypePath) {
-        self.prefix_name(
-            type_path_last_ident(type_path)
-                .to_string()
-                .to_case(Case::Snake),
-        );
+        self.prefix_name(type_path_last_ident(type_path).to_string().to_snake_case());
     }
 
     fn prefix_name<T: Display>(&mut self, prefix: T) {

--- a/safer-ffi-gen-macro/src/ffi_type.rs
+++ b/safer-ffi-gen-macro/src/ffi_type.rs
@@ -1,5 +1,5 @@
 use crate::{has_only_lifetime_parameters, Error, ErrorReason};
-use convert_case::{Case, Casing};
+use heck::ToSnakeCase;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{AttributeArgs, Generics, Ident, ItemStruct, Meta, NestedMeta, Visibility};
@@ -126,7 +126,7 @@ fn export_drop(ty: &Ident, type_visibility: &Visibility, generics: &Generics) ->
 }
 
 fn fn_prefix(ty: &Ident) -> String {
-    ty.to_string().to_case(Case::Snake)
+    ty.to_string().to_snake_case()
 }
 
 #[cfg(test)]

--- a/safer-ffi-gen-macro/src/specialization.rs
+++ b/safer-ffi-gen-macro/src/specialization.rs
@@ -1,5 +1,5 @@
 use crate::{type_path_last_ident, FfiModule};
-use convert_case::{Case, Casing};
+use heck::ToSnakeCase;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{
@@ -46,9 +46,7 @@ pub fn specialization_macro_ident(type_path: &TypePath) -> Ident {
     Ident::new(
         &format!(
             "__safer_ffi_gen_specialize_{}",
-            type_path_last_ident(type_path)
-                .to_string()
-                .to_case(Case::Snake),
+            type_path_last_ident(type_path).to_string().to_snake_case(),
         ),
         Span::call_site(),
     )

--- a/safer-ffi-gen/tests/generic.rs
+++ b/safer-ffi-gen/tests/generic.rs
@@ -22,6 +22,6 @@ safer_ffi_gen::specialize! { FooI32 = Foo<i32> }
 
 #[test]
 fn specialization_works() {
-    let x = foo_i_32_new(33);
-    assert_eq!(*foo_i_32_get(&x), 33);
+    let x = foo_i32_new(33);
+    assert_eq!(*foo_i32_get(&x), 33);
 }


### PR DESCRIPTION
`heck` does not split on number for snake-case, so `FooI32` becomes `foo_i32` and not `foo_i_32`.

Resolves #37