### PR TITLE
`#[repr(C)]` support

### DIFF
--- a/safer-ffi-gen-macro/Cargo.toml
+++ b/safer-ffi-gen-macro/Cargo.toml
@@ -11,7 +11,7 @@ heck = "0.4.1"
 proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn = { version = "2.0.10", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 thiserror = "1.0.39"
 
 [dev-dependencies]

--- a/safer-ffi-gen-macro/src/error.rs
+++ b/safer-ffi-gen-macro/src/error.rs
@@ -41,8 +41,6 @@ pub enum ErrorReason {
 specified with `safer_ffi_gen::specialize` instead"
     )]
     CloneOnGenericType,
-    #[error("`opaque` is required as an argument; only opaque types are supported")]
-    OpaqueRequired,
     #[error("Trait implementation blocks are not supported")]
     TraitImplBlock,
     #[error("Implementation block must be for a type path (e.g. `some_module::some_type`")]
@@ -53,6 +51,10 @@ specified with `safer_ffi_gen::specialize` instead"
     GenericFunction,
     #[error("Unsupported parameter pattern")]
     UnsupportedParamPattern,
+    #[error("Incompatible type representations")]
+    IncompatibleRepr,
+    #[error("Missing type representation")]
+    MissingRepr,
 }
 
 impl ErrorReason {

--- a/safer-ffi-gen-macro/src/ffi_signature.rs
+++ b/safer-ffi-gen-macro/src/ffi_signature.rs
@@ -7,7 +7,7 @@ use quote::{quote, ToTokens};
 use std::{collections::HashMap, fmt::Display};
 use syn::{
     token::SelfType, visit_mut::VisitMut, AngleBracketedGenericArguments, FnArg, GenericArgument,
-    GenericParam, Generics, Ident, Lifetime, LifetimeDef, Pat, PatIdent, PatType, PathArguments,
+    GenericParam, Generics, Ident, Lifetime, LifetimeParam, Pat, PatIdent, PatType, PathArguments,
     PathSegment, PredicateLifetime, QSelf, Receiver, ReturnType, Signature, Type, TypePath,
     TypeReference, WhereClause, WherePredicate,
 };
@@ -17,7 +17,7 @@ pub struct FfiSignature {
     self_type: Type,
     is_async: bool,
     name: Ident,
-    lifetime_params: Vec<LifetimeDef>,
+    lifetime_params: Vec<LifetimeParam>,
     lifetime_predicates: Vec<PredicateLifetime>,
     params: Vec<(Ident, Type)>,
     return_type: ReturnType,

--- a/safer-ffi-gen-macro/src/ffi_type.rs
+++ b/safer-ffi-gen-macro/src/ffi_type.rs
@@ -174,9 +174,8 @@ fn export_drop(ty: &Ident, type_visibility: &Visibility, generics: &Generics) ->
     quote! {
         #[::safer_ffi_gen::safer_ffi::ffi_export]
         #type_visibility fn #drop_ident #impl_generics(
-            x: <#ty #type_generics as ::safer_ffi_gen::FfiType>::Safe,
+            _x: <#ty #type_generics as ::safer_ffi_gen::FfiType>::Safe,
         ) #where_clause {
-            ::core::mem::drop(x);
         }
     }
 }

--- a/safer-ffi-gen-macro/src/lib.rs
+++ b/safer-ffi-gen-macro/src/lib.rs
@@ -1,8 +1,8 @@
 use proc_macro2::{Ident, Span};
 use quote::{quote, ToTokens};
 use syn::{
-    parse_macro_input, spanned::Spanned, AttributeArgs, GenericParam, Generics, PathArguments,
-    TypePath,
+    parse_macro_input, punctuated::Punctuated, spanned::Spanned, GenericParam, Generics, Meta,
+    PathArguments, Token, TypePath,
 };
 
 mod error;
@@ -40,7 +40,7 @@ pub fn ffi_type(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let args = parse_macro_input!(args as AttributeArgs);
+    let args = parse_macro_input!(args with Punctuated::<Meta, Token![,]>::parse_terminated);
     let ty_def = parse_macro_input!(input as syn::ItemStruct);
 
     process_ffi_type(args, ty_def)

--- a/safer-ffi-gen/tests/repr_c.rs
+++ b/safer-ffi-gen/tests/repr_c.rs
@@ -1,0 +1,33 @@
+use safer_ffi_gen::{ffi_type, safer_ffi_gen};
+
+#[ffi_type]
+#[repr(C)]
+pub struct Foo {
+    x: i32,
+}
+
+#[safer_ffi_gen]
+impl Foo {
+    #[safer_ffi_gen]
+    pub fn new(x: i32) -> Self {
+        Self { x }
+    }
+
+    #[safer_ffi_gen]
+    pub fn get(&self) -> i32 {
+        self.x
+    }
+
+    #[safer_ffi_gen]
+    pub fn set(&mut self, x: i32) {
+        self.x = x;
+    }
+}
+
+#[test]
+fn repr_c_works() {
+    let mut a = foo_new(33);
+    assert_eq!(foo_get(&a), 33);
+    foo_set(&mut a, 34);
+    assert_eq!(foo_get(&a), 34);
+}


### PR DESCRIPTION
Support C and transparent representations

Transparent works only for types that have a niche (e.g. `Box<T>`) due to a limitation in `safer-ffi` `0.0.10`. Version `0.1.0` removes this limitation, but is only available as a release candidate for now.

Resolves #45