### PR TITLE
Hide async runtime

### DIFF
--- a/safer-ffi-gen-macro/src/ffi_signature.rs
+++ b/safer-ffi-gen-macro/src/ffi_signature.rs
@@ -195,7 +195,7 @@ impl ToTokens for FfiSignature {
 
         let call = if self.is_async {
             quote! {
-                ::safer_ffi_gen::BLOCKING_ASYNC_RUNTIME.block_on(#call)
+                ::safer_ffi_gen::block_on(#call)
             }
         } else {
             call

--- a/safer-ffi-gen/src/async_util.rs
+++ b/safer-ffi-gen/src/async_util.rs
@@ -1,4 +1,9 @@
 use once_cell::sync::Lazy;
+use std::future::Future;
 use tokio::runtime::Runtime;
 
-pub static BLOCKING_ASYNC_RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().unwrap());
+static BLOCKING_ASYNC_RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().unwrap());
+
+pub fn block_on<F: Future>(f: F) -> F::Output {
+    BLOCKING_ASYNC_RUNTIME.block_on(f)
+}


### PR DESCRIPTION
First step towards allowing other runtimes besides `tokio`.