### PR TITLE
Generate helpers to access opaque items in slice

### DIFF
--- a/safer-ffi-gen/tests/opaque.rs
+++ b/safer-ffi-gen/tests/opaque.rs
@@ -40,3 +40,21 @@ fn by_ref_mut_method_works() {
     foo_inc(&mut x);
     assert_eq!(foo_get(&x), 34);
 }
+
+#[test]
+fn slice_access_works() {
+    let foos = [Foo::new(33), Foo::new(34)];
+    assert_eq!(foo_get(foo_array_get((&foos[..]).into(), 0)), 33);
+    assert_eq!(foo_get(foo_array_get((&foos[..]).into(), 1)), 34);
+}
+
+#[test]
+fn mutable_slice_access_works() {
+    let mut foos = [Foo::new(33), Foo::new(34)];
+    assert_eq!(foo_get(foo_array_get_mut((&mut foos[..]).into(), 0)), 33);
+    assert_eq!(foo_get(foo_array_get_mut((&mut foos[..]).into(), 1)), 34);
+    foo_inc(foo_array_get_mut((&mut foos[..]).into(), 0));
+    foo_inc(foo_array_get_mut((&mut foos[..]).into(), 1));
+    assert_eq!(foo_get(foo_array_get_mut((&mut foos[..]).into(), 0)), 34);
+    assert_eq!(foo_get(foo_array_get_mut((&mut foos[..]).into(), 1)), 35);
+}


### PR DESCRIPTION
For slices of opaque items, the generated C code does not know the item size and only provides a pointer to the first item. This change generates FFI-exported functions per opaque type to access items in slices of such types.