### PR TITLE
Support custom async executor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Clippy no_std
       run: cargo clippy --all-targets --no-default-features --workspace -- -D warnings
     - name: Build Example
-      run: cargo build --examples --features=tokio,tokio/time
+      run: cargo build --examples
     - name: Test
       run: cargo test --all-features --all-targets
     - name: Test no_std

--- a/safer-ffi-gen/Cargo.toml
+++ b/safer-ffi-gen/Cargo.toml
@@ -10,15 +10,12 @@ repository = "https://github.com/tomleavy/safer-ffi-gen"
 
 [features]
 default = ["std"]
-std = ["once_cell?/std", "safer-ffi/std"]
-tokio = ["dep:tokio", "dep:once_cell", "std"]
+std = ["once_cell/std", "safer-ffi/std"]
 
 [dependencies]
 safer-ffi-gen-macro = { path = "../safer-ffi-gen-macro/", version = "0.1.0-rc.1"}
 safer-ffi = { version = "0.0.10", default-features = false, features = ["alloc", "proc_macros", "out-refs"] }
-tokio = {version = "1", features = ["rt-multi-thread"], optional = true}
-once_cell = { version = "1.9", default-features = false, features = ["alloc"], optional = true }
+once_cell = { version = "1.9", default-features = false, features = ["alloc", "critical-section"] }
 
-[[example]]
-name = "basic_usage"
-required-features = ["tokio", "tokio/time"]
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "time"] }

--- a/safer-ffi-gen/examples/basic_usage.rs
+++ b/safer-ffi-gen/examples/basic_usage.rs
@@ -75,6 +75,8 @@ impl TestStruct {
 }
 
 pub fn main() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    safer_ffi_gen::set_block_on_executor(move |f| runtime.block_on(f));
     let test_struct = test_struct_new(vec![0, 1].into(), "test".to_string().into());
 
     assert_eq!(test_struct_do_something_that_fails(&test_struct), -1);

--- a/safer-ffi-gen/src/lib.rs
+++ b/safer-ffi-gen/src/lib.rs
@@ -12,13 +12,10 @@ pub use safer_ffi_gen_macro::*;
 #[cfg_attr(not(feature = "std"), path = "without_std/error.rs")]
 mod error;
 
-#[cfg(feature = "tokio")]
 mod async_util;
 
-pub use error::{last_error, set_last_error};
-
-#[cfg(feature = "tokio")]
 pub use async_util::*;
+pub use error::{last_error, set_last_error};
 
 pub trait FfiType {
     type Safe;


### PR DESCRIPTION
`set_block_on_executor` exists to help with type inference for closures, as otherwise rustc does not infer a higher rank type and requires to spell out the long parameter type.

Resolves #44