### PR TITLE
More fixes & support ignoring functions in impl block

### DIFF
--- a/safer-ffi-gen-macro/src/lib.rs
+++ b/safer-ffi-gen-macro/src/lib.rs
@@ -30,6 +30,15 @@ pub fn safer_ffi_gen(
     input
 }
 
+/// Marker to ignore functions in `impl` block
+#[proc_macro_attribute]
+pub fn safer_ffi_gen_ignore(
+    _: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    item
+}
+
 #[proc_macro_attribute]
 pub fn ffi_type(
     args: proc_macro::TokenStream,

--- a/safer-ffi-gen/src/lib.rs
+++ b/safer-ffi-gen/src/lib.rs
@@ -125,16 +125,17 @@ impl<T: ReprC> FfiType for Box<T> {
 
 impl<T> FfiType for Option<T>
 where
-    Option<T>: ReprC,
+    T: FfiType,
+    Option<T::Safe>: ReprC,
 {
-    type Safe = Option<T>;
+    type Safe = Option<T::Safe>;
 
     fn into_safe(self) -> Self::Safe {
-        self
+        self.map(T::into_safe)
     }
 
     fn from_safe(x: Self::Safe) -> Self {
-        x
+        x.map(T::from_safe)
     }
 }
 

--- a/safer-ffi-gen/tests/array.rs
+++ b/safer-ffi-gen/tests/array.rs
@@ -11,11 +11,11 @@ impl Foo {
         [Self { i }, Self { i }]
     }
 
-    fn get(&self) -> i32 {
+    pub fn get(&self) -> i32 {
         self.i
     }
 
-    fn take_many(_foos: [Foo; 2]) {}
+    pub fn take_many(_foos: [Foo; 2]) {}
 }
 
 #[test]

--- a/safer-ffi-gen/tests/vec.rs
+++ b/safer-ffi-gen/tests/vec.rs
@@ -4,7 +4,7 @@ struct Foo;
 
 #[safer_ffi_gen]
 impl Foo {
-    fn append(mut v: Vec<u8>, x: u8) -> Vec<u8> {
+    pub fn append(mut v: Vec<u8>, x: u8) -> Vec<u8> {
         v.push(x);
         v
     }


### PR DESCRIPTION
- Process only `pub` functions.
- Allow to mark functions as ignored for FFI. This avoids having to split `impl` blocks based on which functions are exposed through FFI. This is another take on solving #54. `#[safer_ffi_gen_ignore]` is a bit odd in that it does nothing and is just used as a marker for `#[safer_ffi_gen]`. If it is applied in a `cfg_attr`, so should `#[safer_ffi_gen]` and the conditions should match.
- Support `Option<&[u8]>`.