### PR TITLE
Update to safer-ffi 0.1.0 and bump versions

### DIFF
--- a/safer-ffi-gen-macro/Cargo.toml
+++ b/safer-ffi-gen-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safer-ffi-gen-macro"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 authors = ["Tom Leavy", "Stephane Raux"]
 description = "Proc macro implementation for safer-ffi-gen"
 edition = "2021"

--- a/safer-ffi-gen/Cargo.toml
+++ b/safer-ffi-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safer-ffi-gen"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 authors = ["Tom Leavy", "Stephane Raux"]
 description = "FFI wrapper generator based on safer-ffi"
 edition = "2021"
@@ -13,7 +13,7 @@ default = ["std"]
 std = ["once_cell/std", "safer-ffi/std"]
 
 [dependencies]
-safer-ffi-gen-macro = { path = "../safer-ffi-gen-macro/", version = "0.1.0-rc.1"}
+safer-ffi-gen-macro = { path = "../safer-ffi-gen-macro/", version = "0.1.0"}
 safer-ffi = { version = "0.1.0", default-features = false, features = ["alloc", "proc_macros"] }
 once_cell = { version = "1.9", default-features = false, features = ["alloc", "critical-section"] }
 

--- a/safer-ffi-gen/Cargo.toml
+++ b/safer-ffi-gen/Cargo.toml
@@ -14,7 +14,7 @@ std = ["once_cell/std", "safer-ffi/std"]
 
 [dependencies]
 safer-ffi-gen-macro = { path = "../safer-ffi-gen-macro/", version = "0.1.0-rc.1"}
-safer-ffi = { version = "=0.1.0-rc1", default-features = false, features = ["alloc", "proc_macros"] }
+safer-ffi = { version = "0.1.0", default-features = false, features = ["alloc", "proc_macros"] }
 once_cell = { version = "1.9", default-features = false, features = ["alloc", "critical-section"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Can the new version of `safer-ffi-gen` be published so it can be used in our other projects?