### PR TITLE
Support enumerations

### DIFF
--- a/safer-ffi-gen-macro/src/enum_to_error_code.rs
+++ b/safer-ffi-gen-macro/src/enum_to_error_code.rs
@@ -59,6 +59,7 @@ pub fn impl_enum_to_error_code(enumeration: ItemEnum) -> Result<TokenStream, Err
 
         #(#cfgs)*
         #[::safer_ffi_gen::safer_ffi::derive_ReprC]
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
         #[repr(i32)]
         #non_exhaustive
         pub enum #discriminant_type {

--- a/safer-ffi-gen-macro/src/error.rs
+++ b/safer-ffi-gen-macro/src/error.rs
@@ -55,6 +55,8 @@ specified with `safer_ffi_gen::specialize` instead"
     MissingRepr,
     #[error("Too many variants")]
     TooManyVariants,
+    #[error("Unsupported item type (only structs and enums are supported)")]
+    UnsupportedItemType,
 }
 
 impl ErrorReason {

--- a/safer-ffi-gen-macro/src/ffi_type.rs
+++ b/safer-ffi-gen-macro/src/ffi_type.rs
@@ -3,8 +3,8 @@ use heck::ToSnakeCase;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{
-    punctuated::Punctuated, spanned::Spanned, Attribute, Generics, Ident, Item, ItemStruct,
-    Lifetime, LifetimeParam, Meta, Token, Visibility,
+    punctuated::Punctuated, spanned::Spanned, Attribute, Fields, Generics, Ident, Item, ItemEnum,
+    ItemStruct, Lifetime, LifetimeParam, Meta, Token, Visibility,
 };
 
 pub fn process_ffi_type(
@@ -15,6 +15,7 @@ pub fn process_ffi_type(
         Item::Struct(type_def) => {
             process_ffi_struct(args, type_def).map(ToTokens::into_token_stream)
         }
+        Item::Enum(type_def) => process_ffi_enum(args, type_def).map(ToTokens::into_token_stream),
         _ => Err(ErrorReason::UnsupportedItemType.spanned(def)),
     }
 }
@@ -23,39 +24,25 @@ fn process_ffi_struct(
     args: Punctuated<Meta, Token![,]>,
     type_def: ItemStruct,
 ) -> Result<FfiStructOutput, Error> {
-    let has_only_lifetime_params = has_only_lifetime_parameters(&type_def.generics);
-
-    let args = args
-        .iter()
-        .try_fold(FfiTypeArgs::default(), |mut acc, arg| match arg {
-            Meta::Path(p) => {
-                if p.is_ident("opaque") {
-                    acc.repr = Some(WithSpan::new(FfiRepr::Opaque, p.span()));
-                    Ok(acc)
-                } else if p.is_ident("clone") {
-                    if has_only_lifetime_params {
-                        acc.clone = Some(p.span());
-                        Ok(acc)
-                    } else {
-                        Err(ErrorReason::CloneOnGenericType.spanned(p))
-                    }
-                } else {
-                    Err(ErrorReason::UnknownArg.spanned(p))
-                }
-            }
-            _ => Err(ErrorReason::UnknownArg.spanned(arg)),
-        })?;
-
-    let ty_repr = type_repr(&type_def.attrs).map(|r| r.map(FfiRepr::from));
-
-    let repr = match (ty_repr, args.repr) {
-        (Some(a), Some(_)) => Err(ErrorReason::IncompatibleRepr.with_span(a.span)),
-        (Some(a), None) | (None, Some(a)) => Ok(a.item),
-        (None, None) => Err(ErrorReason::MissingRepr.with_span(Span::call_site())),
-    }?;
+    let args = FfiTypeArgs::parse(&args, &type_def.generics)?;
+    let opaque = is_opaque(&args, &type_def.attrs)?;
 
     Ok(FfiStructOutput {
-        repr,
+        opaque,
+        type_def,
+        clone: args.clone.is_some(),
+    })
+}
+
+fn process_ffi_enum(
+    args: Punctuated<Meta, Token![,]>,
+    type_def: ItemEnum,
+) -> Result<FfiEnumOutput, Error> {
+    let args = FfiTypeArgs::parse(&args, &type_def.generics)?;
+    let opaque = is_opaque(&args, &type_def.attrs)?;
+
+    Ok(FfiEnumOutput {
+        opaque,
         type_def,
         clone: args.clone.is_some(),
     })
@@ -63,13 +50,42 @@ fn process_ffi_struct(
 
 #[derive(Debug, Default)]
 struct FfiTypeArgs {
-    repr: Option<WithSpan<FfiRepr>>,
+    opaque: Option<Span>,
     clone: Option<Span>,
+}
+
+impl FfiTypeArgs {
+    fn parse(args: &Punctuated<Meta, Token![,]>, generics: &Generics) -> Result<Self, Error> {
+        let has_only_lifetime_params = has_only_lifetime_parameters(generics);
+
+        let args = args
+            .iter()
+            .try_fold(FfiTypeArgs::default(), |mut acc, arg| match arg {
+                Meta::Path(p) => {
+                    if p.is_ident("opaque") {
+                        acc.opaque = Some(p.span());
+                        Ok(acc)
+                    } else if p.is_ident("clone") {
+                        if has_only_lifetime_params {
+                            acc.clone = Some(p.span());
+                            Ok(acc)
+                        } else {
+                            Err(ErrorReason::CloneOnGenericType.spanned(p))
+                        }
+                    } else {
+                        Err(ErrorReason::UnknownArg.spanned(p))
+                    }
+                }
+                _ => Err(ErrorReason::UnknownArg.spanned(arg)),
+            })?;
+
+        Ok(args)
+    }
 }
 
 #[derive(Debug)]
 struct FfiStructOutput {
-    repr: FfiRepr,
+    opaque: bool,
     type_def: ItemStruct,
     clone: bool,
 }
@@ -91,11 +107,11 @@ impl ToTokens for FfiStructOutput {
                 &self.type_def.ident,
                 &self.type_def.vis,
                 &self.type_def.generics,
-                self.repr,
+                self.opaque,
             )
         });
 
-        let slice_access = (has_only_lifetime_params && self.repr == FfiRepr::Opaque).then(|| {
+        let slice_access = (has_only_lifetime_params && self.opaque).then(|| {
             export_slice_access(
                 &self.type_def.ident,
                 &self.type_def.vis,
@@ -104,14 +120,10 @@ impl ToTokens for FfiStructOutput {
         });
 
         let type_def = &self.type_def;
+        let ty_repr = self.opaque.then(|| quote! { #[repr(opaque)] });
 
-        let ty_repr = match self.repr {
-            FfiRepr::C => quote! { #[repr(C)] },
-            FfiRepr::Opaque => quote! { #[repr(opaque)] },
-            FfiRepr::Transparent => quote! { #[repr(transparent)] },
-        };
-
-        let ffi_type_impl = impl_ffi_type(&self.type_def.ident, &self.type_def.generics, self.repr);
+        let ffi_type_impl =
+            impl_ffi_type(&self.type_def.ident, &self.type_def.generics, self.opaque);
 
         let out = quote! {
             #[::safer_ffi_gen::safer_ffi::derive_ReprC]
@@ -130,24 +142,88 @@ impl ToTokens for FfiStructOutput {
     }
 }
 
-fn impl_ffi_type(ty: &Ident, generics: &Generics, repr: FfiRepr) -> TokenStream {
+#[derive(Debug)]
+pub struct FfiEnumOutput {
+    opaque: bool,
+    type_def: ItemEnum,
+    clone: bool,
+}
+
+impl ToTokens for FfiEnumOutput {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let has_only_lifetime_params = has_only_lifetime_parameters(&self.type_def.generics);
+
+        let drop_fn = has_only_lifetime_params.then(|| {
+            export_drop(
+                &self.type_def.ident,
+                &self.type_def.vis,
+                &self.type_def.generics,
+            )
+        });
+
+        let clone_fn = self.clone.then(|| {
+            export_clone(
+                &self.type_def.ident,
+                &self.type_def.vis,
+                &self.type_def.generics,
+                self.opaque,
+            )
+        });
+
+        let slice_access = (has_only_lifetime_params && self.opaque).then(|| {
+            export_slice_access(
+                &self.type_def.ident,
+                &self.type_def.vis,
+                &self.type_def.generics,
+            )
+        });
+
+        let type_def = &self.type_def;
+
+        let ffi_type_impl =
+            impl_ffi_type(&self.type_def.ident, &self.type_def.generics, self.opaque);
+
+        let repr_c_derive = (!self.opaque).then(|| {
+            quote! {
+                #[::safer_ffi_gen::safer_ffi::derive_ReprC]
+            }
+        });
+
+        let repr_c_impl = self.opaque.then(|| impl_c_repr_for_enum(&self.type_def));
+
+        let discriminant = (has_only_lifetime_params && self.opaque)
+            .then(|| generate_enum_discriminant(&self.type_def));
+
+        let variant_accessors = (has_only_lifetime_params && self.opaque)
+            .then(|| generate_enum_accessors(&self.type_def));
+
+        let out = quote! {
+            #repr_c_derive
+            #type_def
+
+            #repr_c_impl
+
+            #ffi_type_impl
+
+            #drop_fn
+
+            #clone_fn
+
+            #slice_access
+
+            #discriminant
+
+            #variant_accessors
+        };
+        out.to_tokens(tokens);
+    }
+}
+
+fn impl_ffi_type(ty: &Ident, generics: &Generics, opaque: bool) -> TokenStream {
     let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
 
-    match repr {
-        FfiRepr::C | FfiRepr::Transparent => quote! {
-            impl #impl_generics ::safer_ffi_gen::FfiType for #ty #type_generics #where_clause {
-                type Safe = #ty #type_generics;
-
-                fn into_safe(self) -> Self::Safe {
-                    self
-                }
-
-                fn from_safe(x: Self::Safe) -> Self {
-                    x
-                }
-            }
-        },
-        FfiRepr::Opaque => quote! {
+    if opaque {
+        quote! {
             impl #impl_generics ::safer_ffi_gen::FfiType for #ty #type_generics #where_clause {
                 type Safe = ::safer_ffi_gen::safer_ffi::boxed::Box_<#ty #type_generics>;
 
@@ -159,26 +235,128 @@ fn impl_ffi_type(ty: &Ident, generics: &Generics, repr: FfiRepr) -> TokenStream 
                     *x.into()
                 }
             }
-        },
+        }
+    } else {
+        quote! {
+            impl #impl_generics ::safer_ffi_gen::FfiType for #ty #type_generics #where_clause {
+                type Safe = #ty #type_generics;
+
+                fn into_safe(self) -> Self::Safe {
+                    self
+                }
+
+                fn from_safe(x: Self::Safe) -> Self {
+                    x
+                }
+            }
+        }
     }
+}
+
+fn impl_c_repr_for_enum(ty_def: &ItemEnum) -> TokenStream {
+    let ty = &ty_def.ident;
+    let (impl_generics, type_generics, where_clause) = ty_def.generics.split_for_impl();
+
+    quote! {
+        unsafe impl #impl_generics ::safer_ffi_gen::safer_ffi::layout::ReprC for #ty #type_generics #where_clause {
+            type CLayout = ::safer_ffi_gen::private::OpaqueLayout<Self>;
+
+            fn is_valid(layout: &Self::CLayout) -> bool {
+                unreachable!("This is never called according to safer-ffi `Opaque` implementation")
+            }
+        }
+    }
+}
+
+fn generate_enum_discriminant(ty_def: &ItemEnum) -> TokenStream {
+    let ty = &ty_def.ident;
+    let discriminant_ty = Ident::new(&format!("{ty}Discriminant"), Span::call_site());
+    let variants = ty_def.variants.iter().map(|v| &v.ident).collect::<Vec<_>>();
+    let (impl_generics, type_generics, where_clause) = ty_def.generics.split_for_impl();
+
+    let arms = variants.iter().map(|v| {
+        quote! {
+            #ty::#v { .. } => #discriminant_ty::#v
+        }
+    });
+
+    let function = Ident::new(
+        &format!("{}_discriminant", ty.to_string().to_snake_case()),
+        Span::call_site(),
+    );
+
+    quote! {
+        #[::safer_ffi_gen::safer_ffi::derive_ReprC]
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        #[repr(u32)]
+        pub enum #discriminant_ty {
+            #(#variants,)*
+        }
+
+        #[::safer_ffi_gen::safer_ffi::ffi_export]
+        pub fn #function #impl_generics(x: &#ty #type_generics) -> #discriminant_ty #where_clause {
+            match *x {
+                #(#arms,)*
+            }
+        }
+    }
+}
+
+fn generate_enum_accessors(ty_def: &ItemEnum) -> TokenStream {
+    let ty = &ty_def.ident;
+    let ty_prefix = ty.to_string().to_snake_case();
+    let (impl_generics, type_generics, where_clause) = ty_def.generics.split_for_impl();
+
+    ty_def
+        .variants
+        .iter()
+        .filter_map(|v| match &v.fields {
+            Fields::Unnamed(fields) => match fields.unnamed.first() {
+                Some(field) if fields.unnamed.len() == 1 => {
+                    let variant = &v.ident;
+
+                    let function = Ident::new(
+                        &format!("{ty_prefix}_to_{}", v.ident.to_string().to_snake_case()),
+                        Span::call_site(),
+                    );
+
+                    let field_ty = &field.ty;
+
+                    Some(quote! {
+                        #[::safer_ffi_gen::safer_ffi::ffi_export]
+                        pub fn #function #impl_generics(x: &#ty #type_generics) -> ::core::option::Option<&#field_ty> #where_clause {
+                            match x {
+                                #ty::#variant(data) => ::core::option::Option::Some(data),
+                                #[allow(unreachable_patterns)]
+                                _ => ::core::option::Option::None,
+                            }
+                        }
+                    })
+                }
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect()
 }
 
 fn export_clone(
     ty: &Ident,
     type_visibility: &Visibility,
     generics: &Generics,
-    repr: FfiRepr,
+    opaque: bool,
 ) -> TokenStream {
     let prefix = fn_prefix(ty);
     let clone_ident = Ident::new(&format!("{prefix}_clone"), Span::call_site());
     let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
-    let return_value = match repr {
-        FfiRepr::Opaque => quote! {
+    let return_value = if opaque {
+        quote! {
             ::safer_ffi_gen::safer_ffi::boxed::Box_::new(::core::clone::Clone::clone(x))
-        },
-        FfiRepr::C | FfiRepr::Transparent => quote! {
+        }
+    } else {
+        quote! {
             ::core::clone::Clone::clone(x)
-        },
+        }
     };
 
     quote! {
@@ -244,78 +422,25 @@ fn fn_prefix(ty: &Ident) -> String {
     ty.to_string().to_snake_case()
 }
 
-fn type_repr(attrs: &[Attribute]) -> Option<WithSpan<TypeRepr>> {
-    attrs
-        .iter()
-        .find(|attr| attr.path().is_ident("repr"))
-        .and_then(|attr| {
-            attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
-                .ok()
-        })
-        .and_then(|args| {
-            args.into_iter().find_map(|meta| match meta {
-                Meta::Path(p) => {
-                    if p.is_ident("C") {
-                        Some(WithSpan::new(TypeRepr::C, p.span()))
-                    } else if p.is_ident("transparent") {
-                        Some(WithSpan::new(TypeRepr::Transparent, p.span()))
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            })
-        })
+fn has_type_repr(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| attr.path().is_ident("repr"))
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum TypeRepr {
-    C,
-    Transparent,
-}
+fn is_opaque(args: &FfiTypeArgs, attrs: &[Attribute]) -> Result<bool, Error> {
+    let opaque = match (has_type_repr(attrs), args.opaque) {
+        (true, Some(span)) => Err(ErrorReason::IncompatibleRepr.with_span(span)),
+        (true, None) => Ok(false),
+        (false, Some(_)) => Ok(true),
+        (false, None) => Err(ErrorReason::MissingRepr.with_span(Span::call_site())),
+    }?;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum FfiRepr {
-    Opaque,
-    C,
-    Transparent,
-}
-
-impl From<TypeRepr> for FfiRepr {
-    fn from(r: TypeRepr) -> FfiRepr {
-        match r {
-            TypeRepr::C => FfiRepr::C,
-            TypeRepr::Transparent => FfiRepr::Transparent,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct WithSpan<T> {
-    item: T,
-    span: Span,
-}
-
-impl<T> WithSpan<T> {
-    fn new(item: T, span: Span) -> Self {
-        Self { item, span }
-    }
-
-    fn map<F, U>(self, f: F) -> WithSpan<U>
-    where
-        F: FnOnce(T) -> U,
-    {
-        WithSpan {
-            item: f(self.item),
-            span: self.span,
-        }
-    }
+    Ok(opaque)
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
-        ffi_type::{process_ffi_struct, type_repr, TypeRepr},
+        ffi_type::{has_type_repr, process_ffi_struct},
         Error, ErrorReason,
     };
     use assert2::assert;
@@ -352,7 +477,7 @@ mod tests {
             #[repr(C)]
             struct Foo(i32);
         };
-        assert!(type_repr(&ty.attrs).unwrap().item == TypeRepr::C);
+        assert!(has_type_repr(&ty.attrs));
     }
 
     #[test]
@@ -361,6 +486,6 @@ mod tests {
             #[repr(transparent)]
             struct Foo(i32);
         };
-        assert!(type_repr(&ty.attrs).unwrap().item == TypeRepr::Transparent);
+        assert!(has_type_repr(&ty.attrs));
     }
 }

--- a/safer-ffi-gen-macro/src/lib.rs
+++ b/safer-ffi-gen-macro/src/lib.rs
@@ -47,7 +47,7 @@ pub fn ffi_type(
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let args = parse_macro_input!(args with Punctuated::<Meta, Token![,]>::parse_terminated);
-    let ty_def = parse_macro_input!(input as syn::ItemStruct);
+    let ty_def = parse_macro_input!(input as syn::Item);
 
     process_ffi_type(args, ty_def)
         .map(ToTokens::into_token_stream)

--- a/safer-ffi-gen/Cargo.toml
+++ b/safer-ffi-gen/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/tomleavy/safer-ffi-gen"
 
 [features]
 default = ["std"]
+headers = ["safer-ffi/headers", "std"]
 std = ["once_cell/std", "safer-ffi/std"]
 
 [dependencies]

--- a/safer-ffi-gen/src/lib.rs
+++ b/safer-ffi-gen/src/lib.rs
@@ -10,6 +10,7 @@ pub use safer_ffi_gen_macro::*;
 
 mod async_util;
 mod error;
+mod opaque;
 
 pub use async_util::*;
 
@@ -23,7 +24,10 @@ pub mod private {
     #[cfg(feature = "std")]
     pub use crate::error::{set_last_error, WrapDebug, WrapError, WrapNotDebug, WrapNotError};
 
-    pub use crate::error::{WrapIntoInt, WrapNotIntoInt};
+    pub use crate::{
+        error::{WrapIntoInt, WrapNotIntoInt},
+        opaque::OpaqueLayout,
+    };
 }
 
 pub trait FfiType {

--- a/safer-ffi-gen/src/opaque.rs
+++ b/safer-ffi-gen/src/opaque.rs
@@ -1,0 +1,49 @@
+use core::marker::PhantomData;
+use safer_ffi::layout::CType;
+
+#[cfg(feature = "headers")]
+use safer_ffi::{
+    headers::{languages::HeaderLanguage, Definer},
+    layout::ReprC,
+};
+
+#[cfg(feature = "headers")]
+use std::io;
+
+pub struct OpaqueLayout<T>(PhantomData<T>);
+
+impl<T> Clone for OpaqueLayout<T> {
+    fn clone(&self) -> Self {
+        OpaqueLayout(PhantomData)
+    }
+}
+
+impl<T> Copy for OpaqueLayout<T> {}
+
+unsafe impl<T> CType for OpaqueLayout<T> {
+    type OPAQUE_KIND = safer_ffi::layout::OpaqueKind::Opaque;
+
+    #[cfg(feature = "headers")]
+    fn short_name() -> String {
+        let s = <<safer_ffi::layout::Opaque<T> as ReprC>::CLayout as CType>::short_name();
+        match s.strip_prefix("Opaque_") {
+            Some(s) => s.into(),
+            None => s,
+        }
+    }
+
+    #[cfg(feature = "headers")]
+    fn define_self__impl(
+        language: &dyn HeaderLanguage,
+        definer: &mut dyn Definer,
+    ) -> io::Result<()> {
+        language.emit_opaque_type(
+            definer,
+            &[&format!(
+                "The layout of {} is subject to change",
+                core::any::type_name::<T>()
+            )],
+            &PhantomData::<Self>,
+        )
+    }
+}

--- a/safer-ffi-gen/tests/enumeration.rs
+++ b/safer-ffi-gen/tests/enumeration.rs
@@ -1,0 +1,22 @@
+use safer_ffi_gen::{ffi_type, safer_ffi_gen};
+
+#[ffi_type]
+#[repr(u8)]
+#[derive(Clone, Copy)]
+pub enum Foo {
+    A,
+    B,
+}
+
+#[safer_ffi_gen]
+impl Foo {
+    pub fn discriminant(&self) -> u8 {
+        *self as u8
+    }
+}
+
+#[test]
+fn c_like_enumeration_is_supported() {
+    assert_eq!(foo_discriminant(&Foo::A), 0);
+    assert_eq!(foo_discriminant(&Foo::B), 1);
+}

--- a/safer-ffi-gen/tests/opaque_enumeration.rs
+++ b/safer-ffi-gen/tests/opaque_enumeration.rs
@@ -1,0 +1,42 @@
+use safer_ffi_gen::{ffi_type, safer_ffi_gen};
+
+#[ffi_type(clone, opaque)]
+#[derive(Clone, Debug)]
+pub enum Foo {
+    A,
+    B(i32),
+    C(Bar),
+}
+
+#[safer_ffi_gen]
+impl Foo {
+    pub fn get_int(&self) -> i32 {
+        match *self {
+            Foo::B(i) => i,
+            _ => 0,
+        }
+    }
+}
+
+#[ffi_type(clone, opaque)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Bar {
+    x: i32,
+}
+
+#[test]
+fn enumeration_with_data_is_supported() {
+    assert_eq!(foo_get_int(&Foo::B(33)), 33);
+}
+
+#[test]
+fn discriminant_is_generated() {
+    assert_eq!(foo_discriminant(&Foo::B(33)), FooDiscriminant::B);
+}
+
+#[test]
+fn variant_accessors_are_generated() {
+    assert_eq!(foo_to_b(&Foo::A), None);
+    assert_eq!(foo_to_b(&Foo::B(33)), Some(&33));
+    assert_eq!(foo_to_c(&Foo::C(Bar { x: 34 })), Some(&Bar { x: 34 }));
+}


### PR DESCRIPTION
- Support field-less enumerations
- Support enumerations with fields:
  - Define mirrored field-less enumeration used as discriminant
  - Define function returning discriminant
  - Define functions to extract the fields of variants with a single field
- Fix duplicated `repr` attribute