### PR TITLE
Replace type parameters with arguments after alias substitution

### DIFF
--- a/safer-ffi-gen-macro/src/ffi_module.rs
+++ b/safer-ffi-gen-macro/src/ffi_module.rs
@@ -61,15 +61,6 @@ impl FfiModule {
 
         let alias_mod = export_module_name(target);
 
-        let replacements = type_parameters(&self.type_path)
-            .cloned()
-            .zip(type_parameters(target).cloned())
-            .collect();
-
-        self.functions
-            .iter_mut()
-            .for_each(|f| f.replace_types(&replacements));
-
         let alias_replacements = self
             .all_named_types()
             .into_iter()
@@ -85,6 +76,15 @@ impl FfiModule {
         self.functions
             .iter_mut()
             .for_each(|f| f.replace_type_constructors(&alias_replacements));
+
+        let replacements = type_parameters(&self.type_path)
+            .cloned()
+            .zip(type_parameters(target).cloned())
+            .collect();
+
+        self.functions
+            .iter_mut()
+            .for_each(|f| f.replace_types(&replacements));
 
         self.type_path = TypePath {
             qself: None,

--- a/safer-ffi-gen/tests/generic.rs
+++ b/safer-ffi-gen/tests/generic.rs
@@ -17,9 +17,13 @@ impl<T> Foo<T> {
 }
 
 safer_ffi_gen::specialize! { FooI32 = Foo<i32> }
+safer_ffi_gen::specialize! { FooI64 = Foo<i64> }
 
 #[test]
 fn specialization_works() {
     let x = foo_i32_new(33);
     assert_eq!(*foo_i32_get(&x), 33);
+
+    let x = foo_i64_new(33);
+    assert_eq!(*foo_i64_get(&x), 33);
 }


### PR DESCRIPTION
Alias substitution ignores the original type parameters, so this would break if they had already been replaced.