### PR TITLE
Add functions for `Vec` access

### DIFF
--- a/safer-ffi-gen-macro/src/ffi_type.rs
+++ b/safer-ffi-gen-macro/src/ffi_type.rs
@@ -409,8 +409,8 @@ fn export_slice_access(
     generics: &Generics,
 ) -> TokenStream {
     let prefix = fn_prefix(ty);
-    let get_ident = Ident::new(&format!("{prefix}_array_get"), Span::call_site());
-    let get_mut_ident = Ident::new(&format!("{prefix}_array_get_mut"), Span::call_site());
+    let get_ident = Ident::new(&format!("{prefix}_slice_get"), Span::call_site());
+    let get_mut_ident = Ident::new(&format!("{prefix}_slice_get_mut"), Span::call_site());
     let (_, type_generics, _) = generics.split_for_impl();
     let lifetime = Lifetime::new("'__safer_ffi_gen_lifetime", Span::call_site());
     let mut generics = generics.clone();

--- a/safer-ffi-gen-macro/src/ffi_type.rs
+++ b/safer-ffi-gen-macro/src/ffi_type.rs
@@ -119,6 +119,14 @@ impl ToTokens for FfiStructOutput {
             )
         });
 
+        let vec_access = (has_only_lifetime_params && self.opaque).then(|| {
+            export_vec_access(
+                &self.type_def.ident,
+                &self.type_def.vis,
+                &self.type_def.generics,
+            )
+        });
+
         let type_def = &self.type_def;
         let ty_repr = self.opaque.then(|| quote! { #[repr(opaque)] });
 
@@ -137,6 +145,8 @@ impl ToTokens for FfiStructOutput {
             #clone_fn
 
             #slice_access
+
+            #vec_access
         };
         out.to_tokens(tokens);
     }
@@ -178,6 +188,14 @@ impl ToTokens for FfiEnumOutput {
             )
         });
 
+        let vec_access = (has_only_lifetime_params && self.opaque).then(|| {
+            export_vec_access(
+                &self.type_def.ident,
+                &self.type_def.vis,
+                &self.type_def.generics,
+            )
+        });
+
         let type_def = &self.type_def;
 
         let ffi_type_impl =
@@ -210,6 +228,8 @@ impl ToTokens for FfiEnumOutput {
             #clone_fn
 
             #slice_access
+
+            #vec_access
 
             #discriminant
 
@@ -414,6 +434,45 @@ fn export_slice_access(
             index: usize,
         ) -> & #lifetime mut #ty #type_generics #where_clause {
             &mut items.as_slice()[index]
+        }
+    }
+}
+
+fn export_vec_access(ty: &Ident, type_visibility: &Visibility, generics: &Generics) -> TokenStream {
+    let prefix = fn_prefix(ty);
+    let vec_new_ident = Ident::new(&format!("{prefix}_vec_new"), Span::call_site());
+    let vec_push_ident = Ident::new(&format!("{prefix}_vec_push"), Span::call_site());
+    let vec_as_slice_ident = Ident::new(&format!("{prefix}_vec_as_slice"), Span::call_site());
+    let vec_as_slice_mut_ident =
+        Ident::new(&format!("{prefix}_vec_as_slice_mut"), Span::call_site());
+    let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        #[::safer_ffi_gen::safer_ffi::ffi_export]
+        #type_visibility fn #vec_new_ident #impl_generics() -> ::safer_ffi_gen::safer_ffi::vec::Vec<#ty #type_generics> #where_clause {
+            ::safer_ffi_gen::safer_ffi::vec::Vec::EMPTY
+        }
+
+        #[::safer_ffi_gen::safer_ffi::ffi_export]
+        #type_visibility fn #vec_push_ident #impl_generics(
+            v: &mut ::safer_ffi_gen::safer_ffi::vec::Vec<#ty #type_generics>,
+            item: <#ty #type_generics as ::safer_ffi_gen::FfiType>::Safe,
+        ) #where_clause {
+            v.with_rust_mut(|v| v.push(<#ty #type_generics as ::safer_ffi_gen::FfiType>::from_safe(item)));
+        }
+
+        #[::safer_ffi_gen::safer_ffi::ffi_export]
+        #type_visibility fn #vec_as_slice_ident #impl_generics(
+            v: &::safer_ffi_gen::safer_ffi::vec::Vec<#ty #type_generics>,
+        ) -> ::safer_ffi_gen::safer_ffi::slice::slice_ref<'_, #ty #type_generics> #where_clause {
+            v.as_ref()
+        }
+
+        #[::safer_ffi_gen::safer_ffi::ffi_export]
+        #type_visibility fn #vec_as_slice_mut_ident #impl_generics(
+            v: &mut ::safer_ffi_gen::safer_ffi::vec::Vec<#ty #type_generics>,
+        ) -> ::safer_ffi_gen::safer_ffi::slice::slice_mut<'_, #ty #type_generics> #where_clause {
+            v.as_mut()
         }
     }
 }

--- a/safer-ffi-gen-macro/src/ffi_type.rs
+++ b/safer-ffi-gen-macro/src/ffi_type.rs
@@ -441,6 +441,7 @@ fn export_slice_access(
 fn export_vec_access(ty: &Ident, type_visibility: &Visibility, generics: &Generics) -> TokenStream {
     let prefix = fn_prefix(ty);
     let vec_new_ident = Ident::new(&format!("{prefix}_vec_new"), Span::call_site());
+    let vec_free_ident = Ident::new(&format!("{prefix}_vec_free"), Span::call_site());
     let vec_push_ident = Ident::new(&format!("{prefix}_vec_push"), Span::call_site());
     let vec_as_slice_ident = Ident::new(&format!("{prefix}_vec_as_slice"), Span::call_site());
     let vec_as_slice_mut_ident =
@@ -451,6 +452,12 @@ fn export_vec_access(ty: &Ident, type_visibility: &Visibility, generics: &Generi
         #[::safer_ffi_gen::safer_ffi::ffi_export]
         #type_visibility fn #vec_new_ident #impl_generics() -> ::safer_ffi_gen::safer_ffi::vec::Vec<#ty #type_generics> #where_clause {
             ::safer_ffi_gen::safer_ffi::vec::Vec::EMPTY
+        }
+
+        #[::safer_ffi_gen::safer_ffi::ffi_export]
+        #type_visibility fn #vec_free_ident #impl_generics(
+            _v: ::safer_ffi_gen::safer_ffi::vec::Vec<#ty #type_generics>,
+        ) #where_clause {
         }
 
         #[::safer_ffi_gen::safer_ffi::ffi_export]

--- a/safer-ffi-gen/src/lib.rs
+++ b/safer-ffi-gen/src/lib.rs
@@ -202,3 +202,6 @@ impl<const N: usize, T: ReprC> FfiType for [T; N] {
         x
     }
 }
+
+#[safer_ffi::ffi_export]
+pub fn vec_u8_free(_v: safer_ffi::vec::Vec<u8>) {}

--- a/safer-ffi-gen/tests/opaque.rs
+++ b/safer-ffi-gen/tests/opaque.rs
@@ -1,6 +1,7 @@
 use safer_ffi_gen::{ffi_type, safer_ffi_gen};
 
 #[ffi_type(opaque)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Foo {
     i: i32,
 }
@@ -54,4 +55,33 @@ fn mutable_slice_access_works() {
     foo_inc(foo_array_get_mut((&mut foos[..]).into(), 1));
     assert_eq!(foo_get(foo_array_get_mut((&mut foos[..]).into(), 0)), 34);
     assert_eq!(foo_get(foo_array_get_mut((&mut foos[..]).into(), 1)), 35);
+}
+
+#[test]
+fn vec_of_opaque_items_can_be_created() {
+    let foos = foo_vec_new();
+    assert_eq!(foos.len(), 0);
+}
+
+#[test]
+fn vec_of_opaque_items_can_be_pushed_to() {
+    let mut foos = foo_vec_new();
+    foo_vec_push(&mut foos, foo_new(33));
+    foo_vec_push(&mut foos, foo_new(34));
+    assert_eq!(&*foos, &[Foo::new(33), Foo::new(34)]);
+}
+
+#[test]
+fn vec_of_opaque_items_can_be_accessed_as_slice() {
+    let mut foos = foo_vec_new();
+    foo_vec_push(&mut foos, foo_new(33));
+    assert_eq!(&*foo_vec_as_slice(&foos), &[Foo::new(33)]);
+}
+
+#[test]
+fn vec_of_opaque_items_can_be_accessed_as_mutable_slice() {
+    let mut foos = foo_vec_new();
+    foo_vec_push(&mut foos, foo_new(33));
+    foo_inc(foo_array_get_mut(foo_vec_as_slice_mut(&mut foos), 0));
+    assert_eq!(&*foos, &[Foo::new(34)]);
 }

--- a/safer-ffi-gen/tests/opaque.rs
+++ b/safer-ffi-gen/tests/opaque.rs
@@ -64,6 +64,13 @@ fn vec_of_opaque_items_can_be_created() {
 }
 
 #[test]
+fn vec_of_opaque_items_can_be_freed() {
+    let mut foos = foo_vec_new();
+    foo_vec_push(&mut foos, foo_new(33));
+    foo_vec_free(foos);
+}
+
+#[test]
 fn vec_of_opaque_items_can_be_pushed_to() {
     let mut foos = foo_vec_new();
     foo_vec_push(&mut foos, foo_new(33));

--- a/safer-ffi-gen/tests/opaque.rs
+++ b/safer-ffi-gen/tests/opaque.rs
@@ -42,19 +42,19 @@ fn by_ref_mut_method_works() {
 #[test]
 fn slice_access_works() {
     let foos = [Foo::new(33), Foo::new(34)];
-    assert_eq!(foo_get(foo_array_get((&foos[..]).into(), 0)), 33);
-    assert_eq!(foo_get(foo_array_get((&foos[..]).into(), 1)), 34);
+    assert_eq!(foo_get(foo_slice_get((&foos[..]).into(), 0)), 33);
+    assert_eq!(foo_get(foo_slice_get((&foos[..]).into(), 1)), 34);
 }
 
 #[test]
 fn mutable_slice_access_works() {
     let mut foos = [Foo::new(33), Foo::new(34)];
-    assert_eq!(foo_get(foo_array_get_mut((&mut foos[..]).into(), 0)), 33);
-    assert_eq!(foo_get(foo_array_get_mut((&mut foos[..]).into(), 1)), 34);
-    foo_inc(foo_array_get_mut((&mut foos[..]).into(), 0));
-    foo_inc(foo_array_get_mut((&mut foos[..]).into(), 1));
-    assert_eq!(foo_get(foo_array_get_mut((&mut foos[..]).into(), 0)), 34);
-    assert_eq!(foo_get(foo_array_get_mut((&mut foos[..]).into(), 1)), 35);
+    assert_eq!(foo_get(foo_slice_get_mut((&mut foos[..]).into(), 0)), 33);
+    assert_eq!(foo_get(foo_slice_get_mut((&mut foos[..]).into(), 1)), 34);
+    foo_inc(foo_slice_get_mut((&mut foos[..]).into(), 0));
+    foo_inc(foo_slice_get_mut((&mut foos[..]).into(), 1));
+    assert_eq!(foo_get(foo_slice_get_mut((&mut foos[..]).into(), 0)), 34);
+    assert_eq!(foo_get(foo_slice_get_mut((&mut foos[..]).into(), 1)), 35);
 }
 
 #[test]
@@ -82,6 +82,6 @@ fn vec_of_opaque_items_can_be_accessed_as_slice() {
 fn vec_of_opaque_items_can_be_accessed_as_mutable_slice() {
     let mut foos = foo_vec_new();
     foo_vec_push(&mut foos, foo_new(33));
-    foo_inc(foo_array_get_mut(foo_vec_as_slice_mut(&mut foos), 0));
+    foo_inc(foo_slice_get_mut(foo_vec_as_slice_mut(&mut foos), 0));
     assert_eq!(&*foos, &[Foo::new(34)]);
 }

--- a/safer-ffi-gen/tests/vec.rs
+++ b/safer-ffi-gen/tests/vec.rs
@@ -14,3 +14,9 @@ impl Foo {
 fn vec_can_be_passed_and_returned() {
     assert_eq!(&*foo_append(vec![0, 1].into(), 2), &[0, 1, 2]);
 }
+
+#[test]
+fn vec_of_bytes_can_be_freed() {
+    let v = vec![33u8].into();
+    safer_ffi_gen::vec_u8_free(v);
+}


### PR DESCRIPTION
Given a FFI-opaque type `Foo`, the following functions are generated for a type marked with `ffi_type(opaque)`:
- `foo_vec_new`: returns an empty vector of `Foo`s.
- `foo_vec_free`: frees a vector of `Foo`s.
- `foo_vec_push`: appends a `Foo` to a vector.
- `foo_vec_as_slice`: returns a vector as a slice.
- `foo_vec_as_slice_mut`: returns a vector as a mutable slice.

`vec_u8_free` allows to free a `Vec<u8>`.