### PR TITLE
Refactoring for specialization

### DIFF
--- a/safer-ffi-gen-macro/Cargo.toml
+++ b/safer-ffi-gen-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safer-ffi-gen-macro"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Tom Leavy", "Stephane Raux"]
 description = "Proc macro implementation for safer-ffi-gen"
 edition = "2021"

--- a/safer-ffi-gen-macro/Cargo.toml
+++ b/safer-ffi-gen-macro/Cargo.toml
@@ -16,7 +16,7 @@ heck = "0.4.1"
 proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2.0.10", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn = { version = "2.0.28", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 thiserror = "1.0.39"
 
 [dev-dependencies]

--- a/safer-ffi-gen-macro/src/enum_to_error_code.rs
+++ b/safer-ffi-gen-macro/src/enum_to_error_code.rs
@@ -1,7 +1,10 @@
-use crate::{attr_is, is_cfg, Error, ErrorReason};
-use proc_macro2::{Span, TokenStream};
+use crate::{
+    utils::{attr_is, is_cfg, new_ident},
+    Error, ErrorReason,
+};
+use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Attribute, Ident, ItemEnum};
+use syn::{Attribute, ItemEnum};
 
 pub fn impl_enum_to_error_code(enumeration: ItemEnum) -> Result<TokenStream, Error> {
     let cfgs = enumeration
@@ -12,7 +15,7 @@ pub fn impl_enum_to_error_code(enumeration: ItemEnum) -> Result<TokenStream, Err
 
     let ty = &enumeration.ident;
     let (impl_generics, ty_generics, where_clause) = enumeration.generics.split_for_impl();
-    let discriminant_type = Ident::new(&format!("{ty}Code"), Span::call_site());
+    let discriminant_type = new_ident(format!("{ty}Code"));
 
     let non_exhaustive = if enumeration.attrs.iter().any(is_non_exhaustive) {
         Some(quote! { #[non_exhaustive] })

--- a/safer-ffi-gen-macro/src/error.rs
+++ b/safer-ffi-gen-macro/src/error.rs
@@ -55,8 +55,14 @@ specified with `safer_ffi_gen::specialize` instead"
     BadReprType,
     #[error("Too many variants")]
     TooManyVariants,
-    #[error("Unsupported item type (only structs and enums are supported)")]
+    #[error("Unsupported item type")]
     UnsupportedItemType,
+    #[error("Unexpected receiver type in free function")]
+    UnexpectedReceiverType,
+    #[error("Missing `ffi_name`")]
+    MissingFfiName,
+    #[error("Unexpected `ffi_name` in generic definition")]
+    UnexpectedFfiName,
 }
 
 impl ErrorReason {

--- a/safer-ffi-gen-macro/src/ffi_signature.rs
+++ b/safer-ffi-gen-macro/src/ffi_signature.rs
@@ -1,203 +1,243 @@
 use crate::{
-    replace_type_path_constructor, type_path_constructor, type_path_last_ident, Error, ErrorReason,
+    utils::{
+        has_only_lifetime_parameters, is_cfg, new_ident, parent_path, specialization_macro_name,
+        string_to_path, PathReplacer, TypeCtor, TypeCtorExtractor, TypeReplacer,
+    },
+    Error, ErrorReason,
 };
-use heck::ToSnakeCase;
+use heck::ToUpperCamelCase;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
-use std::{collections::HashMap, fmt::Display};
+use std::collections::{HashMap, HashSet};
 use syn::{
-    token::SelfType, visit_mut::VisitMut, AngleBracketedGenericArguments, Attribute, FnArg,
-    GenericArgument, GenericParam, Generics, Ident, ImplItemFn, Lifetime, LifetimeParam, Pat,
-    PatIdent, PatType, PathArguments, PathSegment, PredicateLifetime, QSelf, Receiver, ReturnType,
-    Signature, Type, TypePath, TypeReference, WhereClause, WherePredicate,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    visit::Visit,
+    Attribute, FnArg, GenericArgument, GenericParam, Generics, Ident, ItemFn, Lifetime, Pat,
+    PatIdent, PatType, Path, PathArguments, QSelf, ReturnType, Type, TypeParam, TypePath,
+    TypeTuple, Visibility, WherePredicate,
 };
 
-#[derive(Clone, Debug)]
-pub struct FfiSignature {
-    attrs: Vec<Attribute>,
-    self_type: Type,
-    is_async: bool,
-    name: Ident,
-    lifetime_params: Vec<LifetimeParam>,
-    lifetime_predicates: Vec<PredicateLifetime>,
-    params: Vec<(Ident, Type)>,
-    return_type: ReturnType,
-    export_prefix: Option<String>,
+const TYPE_ALIAS_PREFIX: &str = "__SaferFfiGenAlias";
+
+/// Macro arguments
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FfiSignatureOptions {
+    /// Name to expose the function as for FFI
+    ffi_name: Option<Ident>,
 }
 
-impl FfiSignature {
-    pub fn parse(self_type: Type, function: ImplItemFn) -> Result<FfiSignature, Error> {
-        let lifetime_params = function
-            .sig
-            .generics
-            .params
+impl Parse for FfiSignatureOptions {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.is_empty() {
+            return Ok(FfiSignatureOptions { ffi_name: None });
+        }
+
+        let name = Ident::parse(input)?;
+
+        (name == "ffi_name")
+            .then_some(())
+            .ok_or_else(|| ErrorReason::UnknownArg.spanned(name))?;
+
+        let _ = syn::token::Eq::parse(input)?;
+        let ffi_name = Some(Ident::parse(input)?);
+        Ok(FfiSignatureOptions { ffi_name })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Signature {
+    name: Ident,
+    is_async: bool,
+    generics: Generics,
+    params: Vec<(Ident, Type)>,
+    return_type: Type,
+}
+
+impl Signature {
+    fn types_mut(&mut self) -> impl Iterator<Item = &mut Type> {
+        self.params
+            .iter_mut()
+            .map(|(_, ty)| ty)
+            .chain([&mut self.return_type])
+    }
+
+    fn all_type_ctors(&self) -> Vec<TypeCtor> {
+        let mut extractor = TypeCtorExtractor::default();
+
+        self.params
             .iter()
-            .map(|p| match p {
-                GenericParam::Lifetime(l) => Ok(l.clone()),
-                _ => Err(ErrorReason::GenericFunction.spanned(p)),
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(|(_, ty)| ty)
+            .chain([&self.return_type])
+            .for_each(|ty| extractor.visit_type(ty));
 
-        let lifetime_predicates =
-            filter_lifetime_predicates(function.sig.generics.where_clause.as_ref())
-                .cloned()
-                .collect();
+        let type_params = self
+            .generics
+            .type_params()
+            .map(|p| &p.ident)
+            .collect::<HashSet<_>>();
 
-        let params = function
-            .sig
+        let mut ctors = extractor.unique_type_ctors();
+        ctors.retain(|ctor| {
+            let is_type_param = ctor
+                .path
+                .get_ident()
+                .map_or(false, |ctor| type_params.contains(ctor));
+
+            // `Result` must not be aliased as it will be turned into an output parameter
+            let is_result = ctor.arity == 2
+                && ctor.lifetime_arity == 0
+                && ctor
+                    .path
+                    .segments
+                    .last()
+                    .map_or(false, |segment| segment.ident == "Result");
+
+            !is_type_param && !is_result
+        });
+        ctors
+    }
+}
+
+impl ToTokens for Signature {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        syn::Signature::from(self.clone()).to_tokens(tokens)
+    }
+}
+
+impl From<Signature> for syn::Signature {
+    fn from(sig: Signature) -> Self {
+        Self {
+            constness: None,
+            asyncness: sig.is_async.then(Default::default),
+            unsafety: None,
+            abi: None,
+            fn_token: Default::default(),
+            ident: sig.name,
+            generics: sig.generics,
+            paren_token: Default::default(),
+            inputs: sig
+                .params
+                .into_iter()
+                .map(|(ident, ty)| {
+                    FnArg::from(PatType {
+                        attrs: Vec::new(),
+                        pat: Box::new(Pat::Ident(PatIdent {
+                            attrs: Vec::new(),
+                            by_ref: None,
+                            mutability: None,
+                            ident,
+                            subpat: None,
+                        })),
+                        colon_token: Default::default(),
+                        ty: Box::new(ty),
+                    })
+                })
+                .collect(),
+            variadic: None,
+            output: into_non_unit_type(sig.return_type).map_or(ReturnType::Default, |ty| {
+                ReturnType::Type(Default::default(), Box::new(ty))
+            }),
+        }
+    }
+}
+
+impl TryFrom<syn::Signature> for Signature {
+    type Error = Error;
+
+    fn try_from(sig: syn::Signature) -> Result<Self, Self::Error> {
+        let params = sig
             .inputs
             .into_iter()
             .map(|input| match input {
-                FnArg::Receiver(Receiver {
-                    reference,
-                    mutability,
-                    ..
-                }) => Ok((
-                    self_param_name(),
-                    reference
-                        .map(|(and_token, lifetime)| {
-                            Type::Reference(TypeReference {
-                                and_token,
-                                lifetime,
-                                mutability,
-                                elem: Box::new(self_type.clone()),
-                            })
-                        })
-                        .unwrap_or_else(|| self_type.clone()),
-                )),
                 FnArg::Typed(PatType { pat, ty, .. }) => match *pat {
                     Pat::Ident(pat) => Ok((pat.ident, *ty)),
                     pat => Err(ErrorReason::UnsupportedParamPattern.spanned(pat)),
                 },
+                FnArg::Receiver(..) => Err(ErrorReason::UnexpectedReceiverType.spanned(input)),
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut sig = FfiSignature {
-            attrs: function.attrs,
-            self_type: self_type.clone(),
-            is_async: function.sig.asyncness.is_some(),
-            name: function.sig.ident,
-            lifetime_params,
-            lifetime_predicates,
+        let return_type = match sig.output {
+            ReturnType::Default => unit_type(),
+            ReturnType::Type(_, ty) => *ty,
+        };
+
+        Ok(Signature {
+            name: sig.ident,
+            is_async: sig.asyncness.is_some(),
+            generics: sig.generics,
             params,
-            return_type: function.sig.output,
-            export_prefix: None,
-        };
-
-        sig.replace_types(&self_type_replacement(self_type));
-        Ok(sig)
-    }
-
-    pub fn prefix_with_type(&mut self, type_path: &TypePath) {
-        self.prefix_name(type_path_last_ident(type_path).to_string().to_snake_case());
-    }
-
-    fn prefix_name<T: Display>(&mut self, prefix: T) {
-        self.export_prefix = Some(prefix.to_string());
-    }
-
-    pub fn add_generics(&mut self, generics: &Generics) {
-        self.lifetime_params.extend(generics.lifetimes().cloned());
-        self.lifetime_predicates
-            .extend(filter_lifetime_predicates(generics.where_clause.as_ref()).cloned());
-    }
-
-    pub fn replace_types(&mut self, replacements: &HashMap<Type, Type>) {
-        self.edit_types(&mut TypeReplacer { replacements });
-    }
-
-    pub fn replace_type_constructors(&mut self, replacements: &HashMap<TypePath, TypePath>) {
-        self.edit_types(&mut TypePathReplacer { replacements });
-    }
-
-    pub fn all_types(&self) -> impl Iterator<Item = &Type> {
-        std::iter::once(&self.self_type)
-            .chain(self.params.iter().map(|(_, ty)| ty))
-            .chain(match &self.return_type {
-                ReturnType::Default => None,
-                ReturnType::Type(_, ty) => Some(&**ty),
-            })
-    }
-
-    pub fn edit_types<V: VisitMut>(&mut self, visitor: &mut V) {
-        visitor.visit_type_mut(&mut self.self_type);
-
-        self.params
-            .iter_mut()
-            .for_each(|(_, ty)| visitor.visit_type_mut(ty));
-
-        if let ReturnType::Type(_, ty) = &mut self.return_type {
-            visitor.visit_type_mut(ty);
-        }
-    }
-
-    fn make_result_output_parameter(&mut self) {
-        let ReturnType::Type(arrow, return_type) = &self.return_type else {
-            return;
-        };
-
-        let Some(ok_type) = result_ok_type(return_type) else {
-            return;
-        };
-
-        if !type_is_unit(ok_type) {
-            self.params
-                .push((output_param_name(), wrap_output_param_type(ok_type.clone())));
-        }
-
-        self.return_type = ReturnType::Type(
-            *arrow,
-            Box::new(Type::Path(TypePath {
-                qself: None,
-                path: string_to_path(true, "core::ffi::c_int"),
-            })),
-        );
-    }
-
-    fn make_types_ffi_safe(&mut self) {
-        let output_param = output_param_name();
-
-        self.params
-            .iter_mut()
-            .filter(|(name, _)| *name != output_param)
-            .for_each(|(_, ty)| {
-                *ty = make_type_ffi_safe(ty.clone());
-            });
-
-        if let ReturnType::Type(_, ty) = &mut self.return_type {
-            *ty = Box::new(make_type_ffi_safe((**ty).clone()));
-        }
-    }
-
-    fn export(&mut self) {
-        self.is_async = false;
-        self.make_result_output_parameter();
-        self.make_types_ffi_safe();
+            return_type,
+        })
     }
 }
 
-impl ToTokens for FfiSignature {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let mut adapted_sig = self.clone();
-        adapted_sig.export();
-        let signature = Signature::from(adapted_sig);
+impl Parse for Signature {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(syn::Signature::parse(input)?.try_into()?)
+    }
+}
 
-        let arg_conversions = self.params.iter().map(|(name, _)| {
-            quote! {
-                let #name = ::safer_ffi_gen::FfiType::from_safe(#name);
+#[derive(Clone, Debug)]
+pub struct Export {
+    ffi_name: Ident,
+    attrs: Vec<Attribute>,
+    visibility: Visibility,
+    original_fn_prefix: Option<Path>,
+    signature: Signature,
+}
+
+impl ToTokens for Export {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let attrs = &self.attrs;
+        let visibility = &self.visibility;
+        let name = &self.ffi_name;
+        let param_names = self
+            .signature
+            .params
+            .iter()
+            .map(|(name, _)| name)
+            .collect::<Vec<_>>();
+
+        let param_types = self
+            .signature
+            .params
+            .iter()
+            .map(|(_, ty)| make_type_ffi_safe(ty.clone()));
+
+        // Map Result type to output parameter and int return type
+        let MappedReturnType {
+            return_type,
+            out_param_type,
+        } = MappedReturnType::new(&self.signature.return_type);
+
+        let return_type = into_non_unit_type(return_type).map(|ty| {
+            if result_ok_type(&self.signature.return_type).is_some() {
+                quote! { -> #ty }
+            } else {
+                quote! { -> <#ty as ::safer_ffi_gen::FfiType>::Safe }
             }
         });
 
-        let fn_name = &self.name;
-        let inputs = self.params.iter().map(|(name, _)| name);
-        let return_value = return_value_name();
-        let self_type = &self.self_type;
+        let out_param = out_param_type.map(|ty| {
+            let name = output_param_name();
+            quote! {
+                #name: ::safer_ffi_gen::safer_ffi::prelude::Out<'_, <#ty as ::safer_ffi_gen::FfiType>::Safe>
+            }
+        });
 
-        let call = quote! {
-            <#self_type>::#fn_name(#(#inputs,)*)
-        };
+        let (impl_generics, _, where_clause) = self.signature.generics.split_for_impl();
+        let original_fn = &self.signature.name;
 
-        let call = if self.is_async {
+        let prefix = self
+            .original_fn_prefix
+            .as_ref()
+            .map(|prefix| quote! { #prefix:: });
+
+        let call =
+            quote! { #prefix #original_fn(#(::safer_ffi_gen::FfiType::from_safe(#param_names),)*) };
+        let call = if self.signature.is_async {
             quote! {
                 ::safer_ffi_gen::block_on(#call)
             }
@@ -205,177 +245,186 @@ impl ToTokens for FfiSignature {
             call
         };
 
-        let return_expression = match &self.return_type {
-            ReturnType::Default => None,
-            ReturnType::Type(_, ty) => Some(match result_ok_type(ty) {
-                Some(ok_type) => {
-                    let set_output_param = (!type_is_unit(ok_type)).then(|| {
-                        let out_param = output_param_name();
-                        quote! {
-                            let ret = ::safer_ffi_gen::FfiType::into_safe(ret);
-                            #out_param.write(ret);
-                        }
-                    });
-
-                    quote! {
-                        match #return_value {
-                            Ok(ret) => {
-                                #set_output_param
-                                0
-                            }
-                            Err(e) => {
-                                let code = ::safer_ffi_gen::error_code!(e);
-                                ::safer_ffi_gen::set_last_error!(e);
-                                code
-                            }
-                        }
-                    }
-                }
-                None => quote! {
-                    ::safer_ffi_gen::FfiType::into_safe(#return_value)
-                },
-            }),
-        };
-
-        let attrs = &self.attrs;
+        let return_value = return_value_name();
+        let return_expression = make_return_expression(&self.signature.return_type);
 
         quote! {
             #(#attrs)*
             #[::safer_ffi_gen::safer_ffi::ffi_export]
             // Code generated by safer-ffi may trigger this warning
             #[allow(unreachable_code)]
-            pub #signature {
-                #(#arg_conversions)*
-
+            #visibility fn #name #impl_generics(
+                #(#param_names: #param_types,)*
+                #out_param
+            ) #return_type #where_clause {
                 let #return_value = #call;
-
                 #return_expression
+            }
+        }
+        .to_tokens(tokens)
+    }
+}
+
+/// Build expression to be returned from the FFI wrapper function
+fn make_return_expression(return_type: &Type) -> TokenStream {
+    let return_value = return_value_name();
+
+    match result_ok_type(return_type) {
+        Some(ok_type) => {
+            let set_output_param = (!type_is_unit(ok_type)).then(|| {
+                let out_param = output_param_name();
+                quote! {
+                    let ret = ::safer_ffi_gen::FfiType::into_safe(ret);
+                    #out_param.write(ret);
+                }
+            });
+
+            quote! {
+                match #return_value {
+                    Ok(ret) => {
+                        #set_output_param
+                        0
+                    }
+                    Err(e) => {
+                        let code = ::safer_ffi_gen::error_code!(e);
+                        ::safer_ffi_gen::set_last_error!(e);
+                        code
+                    }
+                }
+            }
+        }
+        None => quote! {
+            ::safer_ffi_gen::FfiType::into_safe(#return_value)
+        },
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Specialize {
+    attrs: Vec<Attribute>,
+    signature: Signature,
+}
+
+impl ToTokens for Specialize {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let attrs = &self.attrs;
+        let macro_name = specialization_macro_name(self.signature.name.to_string());
+        let types_to_alias = self.signature.all_type_ctors();
+
+        // Alias all types as they may not be accessible from the module where the specialization
+        // happens.
+        let aliases = types_to_alias
+            .iter()
+            .enumerate()
+            .map(|(i, _)| make_alias(&self.signature.name, i))
+            .collect::<Vec<_>>();
+
+        let alias_defs = types_to_alias.iter().zip(&aliases).map(|(target, alias)| {
+            let def = define_type_alias(alias, target);
+            quote! {
+                #(#attrs)*
+                #def
+            }
+        });
+
+        let replacements = types_to_alias
+            .iter()
+            .zip(&aliases)
+            .map(|(target, alias)| (target.path.clone(), alias.clone().into()))
+            .collect::<HashMap<_, _>>();
+
+        let mut path_replacer = PathReplacer {
+            replacements: &replacements,
+        };
+
+        let mut signature = self.signature.clone();
+
+        signature
+            .types_mut()
+            .for_each(|ty| syn::visit_mut::visit_type_mut(&mut path_replacer, ty));
+
+        quote! {
+            #(#alias_defs)*
+
+            #(#attrs)*
+            #[macro_export]
+            macro_rules! #macro_name {
+                ($alias:ident = $target:expr) => {
+                    ::safer_ffi_gen::__specialize_function!($alias, $target, #signature);
+                }
             }
         }
         .to_tokens(tokens);
     }
 }
 
-impl From<FfiSignature> for Signature {
-    fn from(signature: FfiSignature) -> Self {
-        let has_lifetime = !signature.lifetime_params.is_empty();
+#[derive(Clone, Debug)]
+pub enum FfiSignature {
+    Export(Export),
+    Specialize(Specialize),
+}
 
-        Signature {
-            constness: None,
-            asyncness: signature.is_async.then(Default::default),
-            unsafety: None,
-            abi: None,
-            fn_token: Default::default(),
-            ident: Ident::new(
-                &format!(
-                    "{}{}",
-                    signature
-                        .export_prefix
-                        .as_ref()
-                        .map(|p| format!("{p}_"))
-                        .unwrap_or_default(),
-                    signature.name
-                ),
-                Span::call_site(),
-            ),
-            generics: Generics {
-                lt_token: has_lifetime.then(Default::default),
-                params: signature
-                    .lifetime_params
-                    .into_iter()
-                    .map(GenericParam::Lifetime)
-                    .collect(),
-                gt_token: has_lifetime.then(Default::default),
-                where_clause: (!signature.lifetime_predicates.is_empty()).then(|| WhereClause {
-                    where_token: Default::default(),
-                    predicates: signature
-                        .lifetime_predicates
-                        .into_iter()
-                        .map(WherePredicate::Lifetime)
-                        .collect(),
+impl FfiSignature {
+    pub fn new(options: FfiSignatureOptions, function: ItemFn) -> Result<FfiSignature, Error> {
+        let has_only_lifetime_params = has_only_lifetime_parameters(&function.sig.generics);
+        let attrs = function.attrs.into_iter().filter(is_cfg).collect();
+        let signature = function.sig.try_into()?;
+
+        match (has_only_lifetime_params, options.ffi_name) {
+            (true, Some(ffi_name)) => Ok(Self::Export(Export {
+                ffi_name,
+                attrs,
+                visibility: function.vis,
+                original_fn_prefix: None,
+                signature,
+            })),
+            (false, None) => Ok(Self::Specialize(Specialize { attrs, signature })),
+            (true, None) => Err(ErrorReason::MissingFfiName.with_span(Span::call_site())),
+            (false, Some(ffi_name)) => Err(ErrorReason::UnexpectedFfiName.spanned(ffi_name)),
+        }
+    }
+}
+
+impl ToTokens for FfiSignature {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            FfiSignature::Export(f) => f.to_tokens(tokens),
+            FfiSignature::Specialize(f) => f.to_tokens(tokens),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct MappedReturnType {
+    return_type: Type,
+    out_param_type: Option<Type>,
+}
+
+impl MappedReturnType {
+    fn new(original_return_type: &Type) -> Self {
+        let (out_param_type, return_type) = match result_ok_type(original_return_type) {
+            Some(ok_type) => (
+                into_non_unit_type(ok_type.clone()),
+                Type::Path(TypePath {
+                    qself: None,
+                    path: string_to_path("::core::ffi::c_int"),
                 }),
-            },
-            paren_token: Default::default(),
-            inputs: signature
-                .params
-                .into_iter()
-                .map(|(name, ty)| {
-                    FnArg::Typed(PatType {
-                        attrs: Vec::new(),
-                        pat: Box::new(
-                            PatIdent {
-                                attrs: Vec::new(),
-                                by_ref: None,
-                                mutability: None,
-                                ident: name,
-                                subpat: None,
-                            }
-                            .into(),
-                        ),
-                        colon_token: Default::default(),
-                        ty: Box::new(ty),
-                    })
-                })
-                .collect(),
-            variadic: None,
-            output: signature.return_type,
+            ),
+            None => (None, original_return_type.clone()),
+        };
+
+        Self {
+            return_type,
+            out_param_type,
         }
     }
 }
 
-fn filter_lifetime_predicates(
-    where_clause: Option<&WhereClause>,
-) -> impl Iterator<Item = &PredicateLifetime> {
-    where_clause
-        .into_iter()
-        .flat_map(|w| &w.predicates)
-        .filter_map(|pred| match pred {
-            WherePredicate::Lifetime(l) => Some(l),
-            _ => None,
-        })
-}
-
-fn literally_self_type() -> Type {
-    Type::Path(TypePath {
-        qself: None,
-        path: SelfType {
-            span: Span::call_site(),
-        }
-        .into(),
+fn unit_type() -> Type {
+    Type::Tuple(TypeTuple {
+        paren_token: Default::default(),
+        elems: Default::default(),
     })
-}
-
-fn self_type_replacement(self_type: Type) -> HashMap<Type, Type> {
-    [(literally_self_type(), self_type)].into_iter().collect()
-}
-
-#[derive(Debug)]
-struct TypeReplacer<'a> {
-    replacements: &'a HashMap<Type, Type>,
-}
-
-impl VisitMut for TypeReplacer<'_> {
-    fn visit_type_mut(&mut self, ty: &mut Type) {
-        if let Some(new_ty) = self.replacements.get(ty).cloned() {
-            *ty = new_ty;
-        }
-        syn::visit_mut::visit_type_mut(self, ty);
-    }
-}
-
-#[derive(Debug)]
-struct TypePathReplacer<'a> {
-    replacements: &'a HashMap<TypePath, TypePath>,
-}
-
-impl VisitMut for TypePathReplacer<'_> {
-    fn visit_type_path_mut(&mut self, ty: &mut TypePath) {
-        let ty_ctor = type_path_constructor(ty);
-        if let Some(new_ty_ctor) = self.replacements.get(&ty_ctor) {
-            replace_type_path_constructor(ty, new_ty_ctor);
-        }
-        syn::visit_mut::visit_type_path_mut(self, ty);
-    }
 }
 
 fn result_ok_type(ty: &Type) -> Option<&Type> {
@@ -403,92 +452,231 @@ fn type_is_unit(ty: &Type) -> bool {
     matches!(ty, Type::Tuple(tuple) if tuple.elems.is_empty())
 }
 
+fn into_non_unit_type(ty: Type) -> Option<Type> {
+    Some(ty).filter(|ty| !type_is_unit(ty))
+}
+
 fn make_type_ffi_safe(ty: Type) -> Type {
-    const TARGET_PATH: &str = "safer_ffi_gen::FfiType::Safe";
+    const TARGET_PATH: &str = "::safer_ffi_gen::FfiType::Safe";
 
     Type::Path(TypePath {
         qself: Some(QSelf {
             lt_token: Default::default(),
             ty: Box::new(ty),
-            position: TARGET_PATH.split("::").count() - 1,
+            position: TARGET_PATH.split("::").count() - 2,
             as_token: Some(Default::default()),
             gt_token: Default::default(),
         }),
-        path: string_to_path(true, TARGET_PATH),
+        path: string_to_path(TARGET_PATH),
     })
-}
-
-fn string_to_path(leading_colons: bool, segments: &str) -> syn::Path {
-    syn::Path {
-        leading_colon: leading_colons.then(Default::default),
-        segments: string_to_path_segments(segments).collect(),
-    }
-}
-
-fn string_to_path_segments(segments: &str) -> impl Iterator<Item = PathSegment> + '_ {
-    segments
-        .split("::")
-        .map(|s| PathSegment::from(Ident::new(s, Span::call_site())))
-}
-
-fn wrap_output_param_type(ty: Type) -> Type {
-    Type::Path(TypePath {
-        qself: None,
-        path: syn::Path {
-            leading_colon: Some(Default::default()),
-            segments: string_to_path_segments("safer_ffi_gen::safer_ffi::prelude")
-                .chain(Some(PathSegment {
-                    ident: Ident::new("Out", Span::call_site()),
-                    arguments: PathArguments::AngleBracketed(AngleBracketedGenericArguments {
-                        colon2_token: None,
-                        lt_token: Default::default(),
-                        args: [
-                            GenericArgument::Lifetime(Lifetime::new("'_", Span::call_site())),
-                            GenericArgument::Type(make_type_ffi_safe(ty)),
-                        ]
-                        .into_iter()
-                        .collect(),
-                        gt_token: Default::default(),
-                    }),
-                }))
-                .collect(),
-        },
-    })
-}
-
-fn self_param_name() -> Ident {
-    const SELF_PARAM_NAME: &str = "__safer_ffi_gen_self";
-    Ident::new(SELF_PARAM_NAME, Span::call_site())
 }
 
 fn output_param_name() -> Ident {
     const OUTPUT_PARAM_NAME: &str = "__safer_ffi_gen_out";
-    Ident::new(OUTPUT_PARAM_NAME, Span::call_site())
+    new_ident(OUTPUT_PARAM_NAME)
 }
 
 fn return_value_name() -> Ident {
     const RETURN_VALUE_NAME: &str = "__safer_ffi_gen_ret";
-    Ident::new(RETURN_VALUE_NAME, Span::call_site())
+    new_ident(RETURN_VALUE_NAME)
+}
+
+fn make_alias(function: &Ident, index: usize) -> Ident {
+    let function = function.to_string().to_upper_camel_case();
+    new_ident(format!("{TYPE_ALIAS_PREFIX}{function}Alias{index}"))
+}
+
+fn make_lifetime(i: usize) -> Lifetime {
+    Lifetime::new(&format!("'__safer_ffi_gen_lifetime{i}"), Span::call_site())
+}
+
+fn make_type_param(i: usize) -> Ident {
+    new_ident(format!("__SaferFfiGenType{i}"))
+}
+
+fn define_type_alias(alias: &Ident, target: &TypeCtor) -> TokenStream {
+    let lifetime_args = (0..target.lifetime_arity).map(make_lifetime);
+    let type_args = (0..target.arity).map(make_type_param);
+
+    let args = lifetime_args
+        .map(|arg| quote! { #arg })
+        .chain(type_args.map(|arg| quote! { #arg }))
+        .collect::<Punctuated<_, syn::token::Comma>>();
+
+    let args = if args.is_empty() {
+        None
+    } else {
+        Some(quote! {
+            <#args>
+        })
+    };
+
+    let target = &target.path;
+
+    quote! {
+        pub type #alias #args = #target #args;
+    }
+}
+
+#[derive(Debug)]
+pub struct FunctionSpecialization {
+    alias: Ident,
+    target: Path,
+    signature: Signature,
+}
+
+impl Parse for FunctionSpecialization {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let alias = Ident::parse(input)?;
+        let _ = syn::token::Comma::parse(input)?;
+        let target = Path::parse(input)?;
+        let _ = syn::token::Comma::parse(input)?;
+        let signature = Signature::parse(input)?;
+        Ok(Self {
+            alias,
+            target,
+            signature,
+        })
+    }
+}
+
+impl ToTokens for FunctionSpecialization {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let mut signature = self.signature.clone();
+        let target_parent_path = parent_path(&self.target);
+
+        // All types were aliased and the aliases are defined where the function is defined, so
+        // prepend the function path to the aliases
+        if let Some(parent) = target_parent_path.clone() {
+            let mut prefixer = PathPrefixer { prefix: parent };
+
+            signature
+                .types_mut()
+                .for_each(|ty| syn::visit_mut::visit_type_mut(&mut prefixer, ty))
+        }
+
+        // Get types the function is instantiated with
+        let generic_arguments = self
+            .target
+            .segments
+            .last()
+            .and_then(|segment| match &segment.arguments {
+                PathArguments::AngleBracketed(args) => {
+                    Some(args.args.iter().filter_map(|arg| match arg {
+                        GenericArgument::Type(ty) => Some(ty),
+                        _ => None,
+                    }))
+                }
+                _ => None,
+            })
+            .into_iter()
+            .flatten()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        // Extract type parameters from function signature
+        let (generic_types, other_generic_params) = std::mem::take(&mut signature.generics.params)
+            .into_iter()
+            .fold(
+                (Vec::new(), Punctuated::new()),
+                |(mut generic_types, mut other_generic_params), p| {
+                    match p {
+                        GenericParam::Type(TypeParam { ident, .. }) => {
+                            generic_types.push(Type::Path(TypePath {
+                                qself: None,
+                                path: ident.into(),
+                            }))
+                        }
+                        _ => other_generic_params.push(p),
+                    }
+                    (generic_types, other_generic_params)
+                },
+            );
+
+        // Remove type parameters from function signature
+        signature.generics.params = other_generic_params;
+
+        // Keep only lifetime constraints in `where` clause
+        if let Some(where_clause) = signature.generics.where_clause.as_mut() {
+            where_clause.predicates = std::mem::take(&mut where_clause.predicates)
+                .into_iter()
+                .filter(|predicate| matches!(predicate, WherePredicate::Lifetime(_)))
+                .collect();
+        }
+
+        // Replace type parameters with type arguments the function is instantiated with
+        let mut type_replacer = TypeReplacer {
+            replacements: &generic_types.into_iter().zip(generic_arguments).collect(),
+        };
+
+        signature.types_mut().for_each(|ty| {
+            syn::visit_mut::VisitMut::visit_type_mut(&mut type_replacer, ty);
+        });
+
+        let exported = Export {
+            ffi_name: self.alias.clone(),
+            attrs: Vec::new(),
+            visibility: Visibility::Public(Default::default()),
+            original_fn_prefix: target_parent_path,
+            signature,
+        };
+
+        exported.to_tokens(tokens);
+    }
+}
+
+#[derive(Debug)]
+struct PathPrefixer {
+    prefix: Path,
+}
+
+impl syn::visit_mut::VisitMut for PathPrefixer {
+    fn visit_path_mut(&mut self, p: &mut Path) {
+        if let Some(segment) = p
+            .segments
+            .first()
+            .filter(|segment| segment.ident.to_string().starts_with(TYPE_ALIAS_PREFIX))
+        {
+            let mut new_path = self.prefix.clone();
+            new_path.segments.push(segment.clone());
+            *p = new_path;
+        }
+        syn::visit_mut::visit_path_mut(self, p);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
         ffi_signature::{
-            output_param_name, result_ok_type, type_is_unit, FfiSignature, TypeReplacer,
+            make_alias, output_param_name, result_ok_type, string_to_path, type_is_unit,
+            FfiSignature, FfiSignatureOptions, MappedReturnType, PathPrefixer, Signature,
         },
         test_utils::Pretty,
+        utils::{new_ident, TypeCtor},
     };
     use assert2::assert;
-    use std::collections::HashSet;
-    use syn::{parse_quote, visit_mut::VisitMut, Signature, Type};
+    use quote::ToTokens;
+    use syn::{parse_quote, ItemFn, Type};
 
-    fn replace_types(mut ty: Type, replacements: &[(Type, Type)]) -> Type {
-        TypeReplacer {
-            replacements: &replacements.iter().cloned().collect(),
+    fn signature_options(ffi_name: &str) -> FfiSignatureOptions {
+        FfiSignatureOptions {
+            ffi_name: Some(new_ident(ffi_name)),
         }
-        .visit_type_mut(&mut ty);
-        ty
+    }
+
+    #[test]
+    fn signature_options_can_be_parsed() {
+        let actual_options: FfiSignatureOptions = parse_quote! { ffi_name = foo };
+        let expected_options = signature_options("foo");
+        assert!(actual_options == expected_options);
+    }
+
+    #[test]
+    fn empty_signature_options_can_be_parsed() {
+        let actual_options: FfiSignatureOptions = parse_quote! {};
+        let expected_options = FfiSignatureOptions { ffi_name: None };
+        assert!(actual_options == expected_options);
     }
 
     #[test]
@@ -526,96 +714,207 @@ mod tests {
     }
 
     #[test]
-    fn replacing_single_type_works() {
-        let old_ty: Type = parse_quote! { Foo };
-        let new_ty: Type = parse_quote! { Bar };
-        let ty = replace_types(old_ty.clone(), &[(old_ty, new_ty.clone())]);
-        assert!(ty == new_ty);
+    fn unit_return_type_is_mapped_to_itself() {
+        let ty: Type = parse_quote! { () };
+        let expected = MappedReturnType {
+            return_type: ty.clone(),
+            out_param_type: None,
+        };
+        let actual = MappedReturnType::new(&ty);
+        assert!(actual == expected);
     }
 
     #[test]
-    fn replacing_multiple_types_works() {
-        let (foo, bar): (Type, Type) = (parse_quote! { Foo }, parse_quote! { Bar });
-        let (baz, quux): (Type, Type) = (parse_quote! { Baz }, parse_quote! { Quux });
-        let ty: Type = parse_quote! { (#foo, #bar) };
-        let expected: Type = parse_quote! { (#baz, #quux) };
-        let ty = replace_types(ty, &[(foo, baz), (bar, quux)]);
-        assert!(ty == expected);
+    fn non_result_type_is_mapped_to_itself() {
+        let ty: Type = parse_quote! { i32 };
+        let expected = MappedReturnType {
+            return_type: ty.clone(),
+            out_param_type: None,
+        };
+        let actual = MappedReturnType::new(&ty);
+        assert!(actual == expected);
     }
 
     #[test]
-    fn replacing_type_in_type_param_works() {
-        let old_type: Type = parse_quote! { Foo };
-        let new_type: Type = parse_quote! { Bar };
-        let ty: Type = parse_quote! { Vec<Foo> };
-        let expected: Type = parse_quote! { Vec<Bar> };
-        let ty = replace_types(ty, &[(old_type, new_type)]);
-        assert!(ty == expected);
+    fn result_type_is_mapped_to_output_param_and_error_code() {
+        let ty: Type = parse_quote! { Result<Foo, Error> };
+        let expected = MappedReturnType {
+            return_type: parse_quote! { ::core::ffi::c_int },
+            out_param_type: Some(parse_quote! { Foo }),
+        };
+        let actual = MappedReturnType::new(&ty);
+        assert!(actual == expected);
     }
 
     #[test]
-    fn prefixing_function_name_works() {
-        let mut signature =
-            FfiSignature::parse(parse_quote! { FooBar }, parse_quote! { fn baz() {} }).unwrap();
-
-        signature.prefix_with_type(&parse_quote! { ::test::FooBar });
-        let expected_signature: Signature = parse_quote! { fn foo_bar_baz() };
-        let actual_signature = Signature::from(signature);
-        assert!(actual_signature == expected_signature);
+    fn unit_ok_type_is_only_mapped_to_error_code() {
+        let ty: Type = parse_quote! { Result<(), Error> };
+        let expected = MappedReturnType {
+            return_type: parse_quote! { ::core::ffi::c_int },
+            out_param_type: None,
+        };
+        let actual = MappedReturnType::new(&ty);
+        assert!(actual == expected);
     }
 
     #[test]
     fn making_result_an_output_parameter_works() {
-        let mut signature = FfiSignature::parse(
-            parse_quote! { Foo },
-            parse_quote! { fn bar() -> Result<Bar, Error> {} },
+        let wrapper = FfiSignature::new(
+            signature_options("foo"),
+            parse_quote! {
+                fn bar() -> Result<Bar, Error> {}
+            },
         )
-        .unwrap();
+        .unwrap()
+        .into_token_stream();
 
-        signature.make_result_output_parameter();
         let output_param = output_param_name();
 
-        let expected_signature: Signature = parse_quote! {
-            fn bar(
+        let expected_signature: syn::Signature = parse_quote! {
+            fn foo(
                 #output_param: ::safer_ffi_gen::safer_ffi::prelude::Out<'_, <Bar as ::safer_ffi_gen::FfiType>::Safe>
             ) -> ::core::ffi::c_int
         };
 
-        let actual_signature = Signature::from(signature);
+        let actual_signature = syn::parse2::<ItemFn>(wrapper).unwrap().sig;
         assert!(Pretty(actual_signature) == Pretty(expected_signature));
     }
 
     #[test]
     fn unit_ok_type_does_not_cause_an_output_parameter() {
-        let mut signature = FfiSignature::parse(
-            parse_quote! { Foo },
+        let wrapper = FfiSignature::new(
+            signature_options("foo"),
             parse_quote! { fn bar() -> Result<(), Error> {} },
         )
-        .unwrap();
+        .unwrap()
+        .into_token_stream();
 
-        signature.make_result_output_parameter();
-        let expected_signature: Signature = parse_quote! { fn bar() -> ::core::ffi::c_int };
-        let actual_signature = Signature::from(signature);
-        assert!(actual_signature == expected_signature);
+        let expected_signature: syn::Signature = parse_quote! { fn foo() -> ::core::ffi::c_int };
+        let actual_signature = syn::parse2::<ItemFn>(wrapper).unwrap().sig;
+        assert!(Pretty(actual_signature) == Pretty(expected_signature));
     }
 
     #[test]
-    fn extracting_all_types_works() {
-        let signature = FfiSignature::parse(
-            parse_quote! { Foo },
-            parse_quote! { fn bar(x: Bar) -> Result<i32, ()> {} },
-        )
-        .unwrap();
+    fn signature_type_ctors_can_be_extracted() {
+        let signature: Signature = parse_quote! {
+            fn foo<'a>(a: Foo, b: &Vec<i32>, c: ::alloc::vec::Vec<u8>, d: Baz<'a>) -> Bar
+        };
 
-        let expected_types: HashSet<Type> = [
-            parse_quote! { Foo },
-            parse_quote! { Bar },
-            parse_quote! { Result<i32, ()> },
-        ]
-        .into_iter()
-        .collect();
+        let expected = [
+            TypeCtor {
+                path: string_to_path("::alloc::vec::Vec"),
+                lifetime_arity: 0,
+                arity: 1,
+            },
+            TypeCtor {
+                path: string_to_path("Bar"),
+                lifetime_arity: 0,
+                arity: 0,
+            },
+            TypeCtor {
+                path: string_to_path("Baz"),
+                lifetime_arity: 1,
+                arity: 0,
+            },
+            TypeCtor {
+                path: string_to_path("Foo"),
+                lifetime_arity: 0,
+                arity: 0,
+            },
+            TypeCtor {
+                path: string_to_path("Vec"),
+                lifetime_arity: 0,
+                arity: 1,
+            },
+            TypeCtor {
+                path: string_to_path("i32"),
+                lifetime_arity: 0,
+                arity: 0,
+            },
+            TypeCtor {
+                path: string_to_path("u8"),
+                lifetime_arity: 0,
+                arity: 0,
+            },
+        ];
 
-        let actual_types = signature.all_types().cloned().collect::<HashSet<_>>();
-        assert!(actual_types == expected_types);
+        let actual = signature.all_type_ctors();
+        assert!(actual == expected);
+    }
+
+    #[test]
+    fn extracting_type_ctors_ignores_type_parameters() {
+        let signature: Signature = parse_quote! {
+            fn foo<T>(a: T, b: Vec<T>)
+        };
+
+        let expected = [TypeCtor {
+            path: string_to_path("Vec"),
+            lifetime_arity: 0,
+            arity: 1,
+        }];
+
+        let actual = signature.all_type_ctors();
+        assert!(actual == expected);
+    }
+
+    #[test]
+    fn extracting_type_ctors_ignores_result_type() {
+        let signature: Signature = parse_quote! {
+            fn foo() -> Result<i32, ()>
+        };
+
+        let expected = [TypeCtor {
+            path: string_to_path("i32"),
+            lifetime_arity: 0,
+            arity: 0,
+        }];
+
+        let actual = signature.all_type_ctors();
+        assert!(actual == expected);
+    }
+
+    fn prefix_type(prefix: &str, ty: &mut Type) {
+        let mut prefixer = PathPrefixer {
+            prefix: string_to_path(prefix),
+        };
+        syn::visit_mut::visit_type_mut(&mut prefixer, ty);
+    }
+
+    #[test]
+    fn simple_type_can_be_prefixed() {
+        let id = make_alias(&new_ident("Baz"), 33);
+        let mut actual: Type = parse_quote! { #id };
+        prefix_type("foo::bar", &mut actual);
+        let expected: Type = parse_quote! { foo::bar::#id };
+        assert!(Pretty(actual) == Pretty(expected));
+    }
+
+    #[test]
+    fn absolute_path_can_be_prepended() {
+        let id = make_alias(&new_ident("Baz"), 33);
+        let mut actual: Type = parse_quote! { #id };
+        prefix_type("::foo::bar", &mut actual);
+        let expected: Type = parse_quote! { ::foo::bar::#id };
+        assert!(Pretty(actual) == Pretty(expected));
+    }
+
+    #[test]
+    fn nested_type_can_be_prefixed() {
+        let baz = make_alias(&new_ident("alpha"), 33);
+        let quux = make_alias(&new_ident("alpha"), 34);
+        let mut actual: Type = parse_quote! { #baz<#quux> };
+        prefix_type("foo::bar", &mut actual);
+        let expected: Type = parse_quote! { foo::bar::#baz<foo::bar::#quux> };
+        assert!(Pretty(actual) == Pretty(expected));
+    }
+
+    #[test]
+    fn only_recognized_identifiers_are_prefixed() {
+        let id = make_alias(&new_ident("Bar"), 33);
+        let mut actual: Type = parse_quote! { Foo<#id, Baz> };
+        prefix_type("foo::bar", &mut actual);
+        let expected: Type = parse_quote! { Foo<foo::bar::#id, Baz> };
+        assert!(Pretty(actual) == Pretty(expected));
     }
 }

--- a/safer-ffi-gen-macro/src/ffi_type.rs
+++ b/safer-ffi-gen-macro/src/ffi_type.rs
@@ -1,4 +1,7 @@
-use crate::{has_only_lifetime_parameters, is_cfg, Error, ErrorReason};
+use crate::{
+    utils::{has_only_lifetime_parameters, is_cfg, new_ident},
+    Error, ErrorReason,
+};
 use heck::ToSnakeCase;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
@@ -293,7 +296,7 @@ fn impl_c_repr_for_enum(ty_def: &ItemEnum) -> TokenStream {
 
 fn generate_enum_discriminant(ty_def: &ItemEnum, repr: Option<&Type>) -> TokenStream {
     let ty = &ty_def.ident;
-    let discriminant_ty = Ident::new(&format!("{ty}Discriminant"), Span::call_site());
+    let discriminant_ty = new_ident(format!("{ty}Discriminant"));
     let (impl_generics, type_generics, where_clause) = ty_def.generics.split_for_impl();
 
     let arms = ty_def.variants.iter().map(|v| {
@@ -324,10 +327,7 @@ fn generate_enum_discriminant(ty_def: &ItemEnum, repr: Option<&Type>) -> TokenSt
         }
     });
 
-    let function = Ident::new(
-        &format!("{}_discriminant", ty.to_string().to_snake_case()),
-        Span::call_site(),
-    );
+    let function = new_ident(format!("{}_discriminant", ty.to_string().to_snake_case()));
 
     quote! {
         #[::safer_ffi_gen::safer_ffi::derive_ReprC]
@@ -359,10 +359,8 @@ fn generate_enum_accessors(ty_def: &ItemEnum) -> TokenStream {
                 Some(field) if fields.unnamed.len() == 1 => {
                     let variant = &v.ident;
 
-                    let function = Ident::new(
-                        &format!("{ty_prefix}_to_{}", v.ident.to_string().to_snake_case()),
-                        Span::call_site(),
-                    );
+                    let function = new_ident(
+                        format!("{ty_prefix}_to_{}", v.ident.to_string().to_snake_case()));
 
                     let field_ty = &field.ty;
 
@@ -394,7 +392,7 @@ fn export_clone(
     opaque: bool,
 ) -> TokenStream {
     let prefix = fn_prefix(ty);
-    let clone_ident = Ident::new(&format!("{prefix}_clone"), Span::call_site());
+    let clone_ident = new_ident(format!("{prefix}_clone"));
     let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
     let return_value = if opaque {
         quote! {
@@ -418,7 +416,7 @@ fn export_clone(
 
 fn export_drop(ty: &Ident, type_visibility: &Visibility, generics: &Generics) -> TokenStream {
     let prefix = fn_prefix(ty);
-    let drop_ident = Ident::new(&format!("{prefix}_free"), Span::call_site());
+    let drop_ident = new_ident(format!("{prefix}_free"));
     let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
 
     quote! {
@@ -436,8 +434,8 @@ fn export_slice_access(
     generics: &Generics,
 ) -> TokenStream {
     let prefix = fn_prefix(ty);
-    let get_ident = Ident::new(&format!("{prefix}_slice_get"), Span::call_site());
-    let get_mut_ident = Ident::new(&format!("{prefix}_slice_get_mut"), Span::call_site());
+    let get_ident = new_ident(format!("{prefix}_slice_get"));
+    let get_mut_ident = new_ident(format!("{prefix}_slice_get_mut"));
     let (_, type_generics, _) = generics.split_for_impl();
     let lifetime = Lifetime::new("'__safer_ffi_gen_lifetime", Span::call_site());
     let mut generics = generics.clone();
@@ -467,12 +465,11 @@ fn export_slice_access(
 
 fn export_vec_access(ty: &Ident, type_visibility: &Visibility, generics: &Generics) -> TokenStream {
     let prefix = fn_prefix(ty);
-    let vec_new_ident = Ident::new(&format!("{prefix}_vec_new"), Span::call_site());
-    let vec_free_ident = Ident::new(&format!("{prefix}_vec_free"), Span::call_site());
-    let vec_push_ident = Ident::new(&format!("{prefix}_vec_push"), Span::call_site());
-    let vec_as_slice_ident = Ident::new(&format!("{prefix}_vec_as_slice"), Span::call_site());
-    let vec_as_slice_mut_ident =
-        Ident::new(&format!("{prefix}_vec_as_slice_mut"), Span::call_site());
+    let vec_new_ident = new_ident(format!("{prefix}_vec_new"));
+    let vec_free_ident = new_ident(format!("{prefix}_vec_free"));
+    let vec_push_ident = new_ident(format!("{prefix}_vec_push"));
+    let vec_as_slice_ident = new_ident(format!("{prefix}_vec_as_slice"));
+    let vec_as_slice_mut_ident = new_ident(format!("{prefix}_vec_as_slice_mut"));
     let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
 
     quote! {

--- a/safer-ffi-gen-macro/src/lib.rs
+++ b/safer-ffi-gen-macro/src/lib.rs
@@ -1,9 +1,5 @@
-use proc_macro2::{Ident, Span};
 use quote::ToTokens;
-use syn::{
-    parse_macro_input, punctuated::Punctuated, spanned::Spanned, Attribute, GenericParam, Generics,
-    Meta, PathArguments, Token, TypePath,
-};
+use syn::{parse_macro_input, punctuated::Punctuated, Item, Meta, Token};
 
 mod enum_to_error_code;
 mod error;
@@ -13,23 +9,40 @@ mod ffi_type;
 mod specialization;
 #[cfg(test)]
 mod test_utils;
+mod utils;
 
 use enum_to_error_code::impl_enum_to_error_code;
 use error::{Error, ErrorReason};
-use ffi_module::FfiModule;
-use ffi_signature::FfiSignature;
+use ffi_module::{FfiModule, ImplSpecialization};
+use ffi_signature::{FfiSignature, FfiSignatureOptions, FunctionSpecialization};
 use ffi_type::process_ffi_type;
-use specialization::{Specialization, SpecializationDecl};
+use specialization::Specialization;
 
 #[proc_macro_attribute]
 pub fn safer_ffi_gen(
-    _attr: proc_macro::TokenStream,
-    item: proc_macro::TokenStream,
+    attr: proc_macro::TokenStream,
+    mut item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let mut input = item.clone();
-    let output = parse_macro_input!(item as FfiModule);
-    input.extend([proc_macro::TokenStream::from(output.to_token_stream())]);
-    input
+    let input = {
+        let item = item.clone();
+        parse_macro_input!(item as Item)
+    };
+
+    let output = match input {
+        Item::Fn(f) => {
+            let options = parse_macro_input!(attr as FfiSignatureOptions);
+            FfiSignature::new(options, f).map(ToTokens::into_token_stream)
+        }
+        Item::Impl(impl_block) => FfiModule::new(impl_block).map(ToTokens::into_token_stream),
+        _ => Err(ErrorReason::UnsupportedItemType.spanned(input)),
+    };
+
+    let output = output
+        .map_err(Into::into)
+        .unwrap_or_else(syn::Error::into_compile_error);
+
+    item.extend([proc_macro::TokenStream::from(output)]);
+    item
 }
 
 /// Marker to ignore functions in `impl` block
@@ -72,148 +85,20 @@ pub fn enum_to_error_code(
 
 #[proc_macro]
 pub fn specialize(args: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let decl = parse_macro_input!(args as SpecializationDecl);
+    let decl = parse_macro_input!(args as Specialization);
     decl.to_token_stream().into()
 }
 
 #[doc(hidden)]
 #[proc_macro]
-pub fn __specialize(args: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let specialization = parse_macro_input!(args as Specialization);
+pub fn __specialize_impl(args: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let specialization = parse_macro_input!(args as ImplSpecialization);
     specialization.to_token_stream().into()
 }
 
-fn type_path_last_ident(p: &TypePath) -> &Ident {
-    &p.path
-        .segments
-        .last()
-        .expect("Path has at least one segment")
-        .ident
-}
-
-fn has_only_lifetime_parameters(generics: &Generics) -> bool {
-    non_lifetime_parameter(generics).is_none()
-}
-
-fn non_lifetime_parameter(generics: &Generics) -> Option<Span> {
-    generics.params.iter().find_map(|p| match p {
-        GenericParam::Const(p) => Some(p.span()),
-        GenericParam::Type(p) => Some(p.span()),
-        GenericParam::Lifetime(_) => None,
-    })
-}
-
-fn type_path_constructor(path: &TypePath) -> TypePath {
-    let mut p = match &path.qself {
-        Some(qself) => TypePath {
-            qself: None,
-            path: syn::Path {
-                leading_colon: path.path.leading_colon,
-                segments: path
-                    .path
-                    .segments
-                    .iter()
-                    .take(qself.position)
-                    .cloned()
-                    .collect(),
-            },
-        },
-        None => path.clone(),
-    };
-
-    if let Some(segment) = p.path.segments.last_mut() {
-        segment.arguments = PathArguments::None;
-    }
-
-    p
-}
-
-fn replace_type_path_constructor(path: &mut TypePath, replacement: &TypePath) {
-    let ctor_end = match &mut path.qself {
-        Some(qself) => {
-            let end = qself.position;
-            qself.position = replacement.path.segments.len();
-            end
-        }
-        None => path.path.segments.len(),
-    };
-    let args = path.path.segments[ctor_end - 1].arguments.clone();
-    let tail = path
-        .path
-        .segments
-        .iter()
-        .skip(ctor_end)
-        .cloned()
-        .collect::<Vec<_>>();
-    path.path.leading_colon = replacement.path.leading_colon;
-    path.path.segments = replacement.path.segments.iter().cloned().collect();
-    path.path.segments.last_mut().unwrap().arguments = args;
-    path.path.segments.extend(tail);
-}
-
-fn attr_is(attr: &Attribute, id: &str) -> bool {
-    attr.path().get_ident().map_or(false, |i| i == id)
-}
-
-fn is_cfg(attr: &Attribute) -> bool {
-    attr_is(attr, "cfg")
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{replace_type_path_constructor, type_path_constructor};
-    use assert2::assert;
-    use syn::{parse_quote, TypePath};
-
-    #[test]
-    fn type_path_constructor_works_for_simple_type() {
-        let expected: TypePath = parse_quote! { Foo };
-        let actual = type_path_constructor(&parse_quote! { Foo });
-        assert!(actual == expected);
-    }
-
-    #[test]
-    fn type_path_constructor_works_for_generic_type() {
-        let expected: TypePath = parse_quote! { Foo };
-        let actual = type_path_constructor(&parse_quote! { Foo<T> });
-        assert!(actual == expected);
-    }
-
-    #[test]
-    fn type_path_constructor_works_for_associated_type() {
-        let expected: TypePath = parse_quote! { bar::Bar };
-        let actual = type_path_constructor(&parse_quote! { <Foo as bar::Bar>::Output });
-        assert!(actual == expected);
-    }
-
-    #[test]
-    fn type_path_constructor_preserves_module() {
-        let expected: TypePath = parse_quote! { foo::Foo };
-        let actual = type_path_constructor(&parse_quote! { foo::Foo });
-        assert!(actual == expected);
-    }
-
-    #[test]
-    fn replacing_type_path_constructor_works() {
-        let mut ty: TypePath = parse_quote! { Foo };
-        replace_type_path_constructor(&mut ty, &parse_quote! { Bar });
-        let expected = parse_quote! { Bar };
-        assert!(ty == expected);
-    }
-
-    #[test]
-    fn replacing_type_path_constructor_works_for_generic_type() {
-        let mut ty: TypePath = parse_quote! { Foo<T> };
-        replace_type_path_constructor(&mut ty, &parse_quote! { Bar });
-        let expected = parse_quote! { Bar<T> };
-        assert!(ty == expected);
-    }
-
-    #[test]
-    fn replacing_type_path_constructor_works_for_associated_type() {
-        let mut ty: TypePath = parse_quote! { <Foo as bar::Bar>::Output };
-        replace_type_path_constructor(&mut ty, &parse_quote! { baz::Baz });
-        let expected = parse_quote! { <Foo as baz::Baz>::Output };
-        assert!(ty == expected);
-    }
+#[doc(hidden)]
+#[proc_macro]
+pub fn __specialize_function(args: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let specialization = parse_macro_input!(args as FunctionSpecialization);
+    specialization.to_token_stream().into()
 }

--- a/safer-ffi-gen-macro/src/specialization.rs
+++ b/safer-ffi-gen-macro/src/specialization.rs
@@ -1,84 +1,45 @@
-use crate::{type_path_last_ident, FfiModule};
-use heck::ToSnakeCase;
-use proc_macro2::{Span, TokenStream};
+use crate::utils::{parent_path, specialization_macro_name};
+use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{
     parse::{Parse, ParseStream},
-    Ident, TypePath,
+    Ident, Path,
 };
 
 #[derive(Debug)]
-pub struct SpecializationDecl {
-    alias: Ident,
-    target: TypePath,
-}
-
-impl Parse for SpecializationDecl {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let alias = Ident::parse(input)?;
-        let _ = syn::token::Eq::parse(input)?;
-        let target = TypePath::parse(input)?;
-        Ok(Self { alias, target })
-    }
-}
-
-impl ToTokens for SpecializationDecl {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let macro_path = if self.target.path.segments.len() < 2
-            || self.target.path.segments[0].ident == "crate"
-        {
-            specialization_macro_ident(&self.target).into()
-        } else {
-            syn::Path {
-                leading_colon: self.target.path.leading_colon,
-                segments: [
-                    self.target.path.segments[0].clone(),
-                    specialization_macro_ident(&self.target).into(),
-                ]
-                .into_iter()
-                .collect(),
-            }
-        };
-
-        let alias = &self.alias;
-        let target = &self.target;
-
-        quote! {
-            #macro_path! { #alias = #target }
-        }
-        .to_tokens(tokens)
-    }
-}
-
-pub fn specialization_macro_ident(type_path: &TypePath) -> Ident {
-    Ident::new(
-        &format!(
-            "__safer_ffi_gen_specialize_{}",
-            type_path_last_ident(type_path).to_string().to_snake_case(),
-        ),
-        Span::call_site(),
-    )
-}
-
-#[derive(Debug)]
 pub struct Specialization {
-    mini_impl_block: FfiModule,
+    alias: Ident,
+    target: Path,
 }
 
 impl Parse for Specialization {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let alias = Ident::parse(input)?;
-        let _ = syn::token::Comma::parse(input)?;
-        let target = TypePath::parse(input)?;
-        let _ = syn::token::Comma::parse(input)?;
-        let mut mini_impl_block = FfiModule::parse(input)?;
-        mini_impl_block.specialize(&alias, &target);
-        Ok(Self { mini_impl_block })
+        let _ = syn::token::Eq::parse(input)?;
+        let target = Path::parse(input)?;
+        Ok(Self { alias, target })
     }
 }
 
 impl ToTokens for Specialization {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        self.mini_impl_block.to_tokens(tokens);
+        let prefix = parent_path(&self.target)
+            .filter(|p| p.segments.first().unwrap().ident != "crate")
+            .map(|p| {
+                let leading_colon = p.leading_colon;
+                let p = p.segments.first().unwrap();
+                quote! { #leading_colon #p:: }
+            });
+
+        let macro_id =
+            specialization_macro_name(self.target.segments.last().unwrap().ident.to_string());
+
+        let alias = &self.alias;
+        let target = &self.target;
+
+        quote! {
+            #prefix #macro_id! { #alias = #target }
+        }
+        .to_tokens(tokens)
     }
 }

--- a/safer-ffi-gen-macro/src/utils.rs
+++ b/safer-ffi-gen-macro/src/utils.rs
@@ -1,0 +1,372 @@
+use heck::ToSnakeCase;
+use proc_macro2::Span;
+use quote::ToTokens;
+use std::collections::{HashMap, HashSet};
+use syn::{
+    parse::{Parse, ParseStream},
+    Attribute, GenericArgument, GenericParam, Generics, Ident, Lifetime, Path, PathArguments,
+    PathSegment, ReturnType, Type, TypePath,
+};
+
+pub fn has_only_lifetime_parameters(generics: &Generics) -> bool {
+    generics
+        .params
+        .iter()
+        .all(|p| matches!(p, GenericParam::Lifetime(_)))
+}
+
+pub fn attr_is(attr: &Attribute, id: &str) -> bool {
+    attr.path().get_ident().map_or(false, |i| i == id)
+}
+
+pub fn is_cfg(attr: &Attribute) -> bool {
+    attr_is(attr, "cfg")
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct TypeCtor {
+    pub path: Path,
+    pub lifetime_arity: usize,
+    pub arity: usize,
+}
+
+impl From<Path> for TypeCtor {
+    fn from(mut path: Path) -> Self {
+        let (arity, lifetime_arity) = path
+            .segments
+            .last()
+            .and_then(|segment| match &segment.arguments {
+                PathArguments::AngleBracketed(args) => Some(&args.args),
+                _ => None,
+            })
+            .into_iter()
+            .flatten()
+            .fold((0, 0), |(arity, lifetime_arity), arg| {
+                (
+                    arity + matches!(arg, GenericArgument::Type(_)) as usize,
+                    lifetime_arity + matches!(arg, GenericArgument::Lifetime(_)) as usize,
+                )
+            });
+
+        if let Some(segment) = path.segments.last_mut() {
+            segment.arguments = PathArguments::None;
+        }
+
+        Self {
+            path,
+            arity,
+            lifetime_arity,
+        }
+    }
+}
+
+impl Parse for TypeCtor {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Path::parse(input).map(Into::into)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct TypeCtorExtractor {
+    ctors: Vec<TypeCtor>,
+}
+
+impl TypeCtorExtractor {
+    pub fn unique_type_ctors(&self) -> Vec<TypeCtor> {
+        let mut ctors = self
+            .ctors
+            .iter()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        ctors.sort_by_cached_key(|ty| {
+            (
+                ty.path.to_token_stream().to_string(),
+                ty.arity,
+                ty.lifetime_arity,
+            )
+        });
+
+        ctors
+    }
+}
+
+impl<'a> syn::visit::Visit<'a> for TypeCtorExtractor {
+    fn visit_type_path(&mut self, ty: &'a TypePath) {
+        if ty.qself.is_none() {
+            self.ctors.push(ty.path.clone().into());
+            syn::visit::visit_type_path(self, ty);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TypeReplacer<'a> {
+    pub replacements: &'a HashMap<Type, Type>,
+}
+
+impl syn::visit_mut::VisitMut for TypeReplacer<'_> {
+    fn visit_type_mut(&mut self, ty: &mut Type) {
+        if let Some(new_ty) = self.replacements.get(ty).cloned() {
+            *ty = new_ty;
+        }
+        syn::visit_mut::visit_type_mut(self, ty);
+    }
+}
+
+#[derive(Debug)]
+pub struct PathReplacer<'a> {
+    pub replacements: &'a HashMap<Path, Path>,
+}
+
+impl syn::visit_mut::VisitMut for PathReplacer<'_> {
+    fn visit_path_mut(&mut self, p: &mut Path) {
+        let path_without_args = remove_path_args(p.clone());
+        if let Some(mut new_path) = self.replacements.get(&path_without_args).cloned() {
+            let args = p
+                .segments
+                .last_mut()
+                .map_or_else(Default::default, |p| std::mem::take(&mut p.arguments));
+
+            if let Some(segment) = new_path.segments.last_mut() {
+                segment.arguments = args;
+            }
+
+            *p = new_path;
+        }
+        syn::visit_mut::visit_path_mut(self, p);
+    }
+}
+
+#[derive(Debug)]
+pub struct LifetimeInserter {
+    pub lifetime: Lifetime,
+}
+
+impl LifetimeInserter {
+    pub fn new(lifetime: Lifetime) -> Self {
+        Self { lifetime }
+    }
+}
+
+impl syn::visit_mut::VisitMut for LifetimeInserter {
+    fn visit_lifetime_mut(&mut self, lifetime: &mut Lifetime) {
+        if is_placeholder_lifetime(lifetime) {
+            *lifetime = self.lifetime.clone();
+        }
+    }
+
+    fn visit_type_reference_mut(&mut self, ty: &mut syn::TypeReference) {
+        if ty.lifetime.is_none() {
+            ty.lifetime = Some(self.lifetime.clone());
+        }
+        syn::visit_mut::visit_type_reference_mut(self, ty);
+    }
+}
+
+#[derive(Debug, Default)]
+struct HasImplicitLifetime {
+    found: bool,
+}
+
+impl<'a> syn::visit::Visit<'a> for HasImplicitLifetime {
+    fn visit_lifetime(&mut self, lifetime: &'a Lifetime) {
+        self.found = self.found || is_placeholder_lifetime(lifetime);
+    }
+
+    fn visit_type_reference(&mut self, ty: &'a syn::TypeReference) {
+        self.found = self.found
+            || ty
+                .lifetime
+                .as_ref()
+                .filter(|lt| !is_placeholder_lifetime(lt))
+                .is_none();
+
+        if !self.found {
+            syn::visit::visit_type_reference(self, ty);
+        }
+    }
+}
+
+pub fn type_has_implicit_lifetime(ty: &Type) -> bool {
+    let mut finder = HasImplicitLifetime::default();
+    syn::visit::visit_type(&mut finder, ty);
+    finder.found
+}
+
+pub fn return_type_has_implicit_lifetime(ty: &ReturnType) -> bool {
+    match ty {
+        ReturnType::Default => false,
+        ReturnType::Type(_, ty) => type_has_implicit_lifetime(ty),
+    }
+}
+
+pub fn remove_path_args(mut p: Path) -> Path {
+    if let Some(p) = p.segments.last_mut() {
+        p.arguments = PathArguments::None;
+    }
+    p
+}
+
+pub fn parent_path(p: &Path) -> Option<Path> {
+    let mut p = p.clone();
+    p.segments.pop();
+    p.segments.pop_punct();
+    Some(p).filter(|p| !p.segments.is_empty())
+}
+
+pub fn new_ident<S>(s: S) -> Ident
+where
+    S: AsRef<str>,
+{
+    Ident::new(s.as_ref(), Span::call_site())
+}
+
+pub fn string_to_path(segments: &str) -> syn::Path {
+    let s = segments.strip_prefix("::");
+    let leading_colon = s.map(|_| Default::default());
+    let segments = s.unwrap_or(segments);
+    syn::Path {
+        leading_colon,
+        segments: string_to_path_segments(segments).collect(),
+    }
+}
+
+fn string_to_path_segments(segments: &str) -> impl Iterator<Item = PathSegment> + '_ {
+    segments
+        .split("::")
+        .map(|s| PathSegment::from(new_ident(s)))
+}
+
+pub fn specialization_macro_name<S>(s: S) -> Ident
+where
+    S: AsRef<str>,
+{
+    new_ident(format!(
+        "__safer_ffi_gen_specialize_{}",
+        s.as_ref().to_snake_case(),
+    ))
+}
+
+pub fn is_placeholder_lifetime(lifetime: &Lifetime) -> bool {
+    lifetime.ident == "'_"
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        test_utils::Pretty,
+        utils::{is_cfg, string_to_path, TypeCtor, TypeCtorExtractor},
+    };
+    use assert2::check;
+    use syn::{parse_quote, Attribute, Path, Type};
+
+    #[test]
+    fn is_cfg_returns_true_for_cfg_attribute() {
+        let attr: Attribute = parse_quote! { #[cfg(test)] };
+        check!(is_cfg(&attr));
+    }
+
+    #[test]
+    fn is_cfg_returns_false_for_non_cfg_attribute() {
+        let attr: Attribute = parse_quote! { #[test] };
+        check!(!is_cfg(&attr));
+    }
+
+    #[test]
+    fn absolute_path_can_be_created_from_string() {
+        let actual = string_to_path("::foo::bar::baz");
+        let expected: Path = parse_quote! { ::foo::bar::baz };
+        check!(Pretty(actual) == Pretty(expected));
+    }
+
+    #[test]
+    fn relative_path_can_be_created_from_string() {
+        let actual = string_to_path("foo::bar::baz");
+        let expected: Path = parse_quote! { foo::bar::baz };
+        check!(Pretty(actual) == Pretty(expected));
+    }
+
+    #[test]
+    fn type_constructor_has_arity_zero_when_there_are_no_generic_arguments() {
+        let actual: TypeCtor = parse_quote! { Foo };
+        let expected = TypeCtor {
+            path: parse_quote! { Foo },
+            arity: 0,
+            lifetime_arity: 0,
+        };
+
+        check!(actual == expected);
+    }
+
+    #[test]
+    fn type_constructor_has_arity_one_when_there_is_one_type_argument() {
+        let actual: TypeCtor = parse_quote! { Foo<T> };
+        let expected = TypeCtor {
+            path: parse_quote! { Foo },
+            arity: 1,
+            lifetime_arity: 0,
+        };
+
+        check!(actual == expected);
+    }
+
+    #[test]
+    fn type_constructor_has_lifetime_arity_one_when_there_is_one_lifetime_argument() {
+        let actual: TypeCtor = parse_quote! { Foo<'a> };
+        let expected = TypeCtor {
+            path: parse_quote! { Foo },
+            arity: 0,
+            lifetime_arity: 1,
+        };
+
+        check!(actual == expected);
+    }
+
+    #[test]
+    fn type_constructor_has_correct_arities() {
+        let actual: TypeCtor = parse_quote! { Foo<'a, 'b, T, U, V> };
+        let expected = TypeCtor {
+            path: parse_quote! { Foo },
+            arity: 3,
+            lifetime_arity: 2,
+        };
+
+        check!(actual == expected);
+    }
+
+    #[test]
+    fn type_ctors_can_be_extracted() {
+        let ty: Type = parse_quote! { Foo<bar::Bar, i32, Baz<i32>> };
+        let mut extractor = TypeCtorExtractor::default();
+
+        let expected = [
+            TypeCtor {
+                path: string_to_path("Baz"),
+                lifetime_arity: 0,
+                arity: 1,
+            },
+            TypeCtor {
+                path: string_to_path("Foo"),
+                lifetime_arity: 0,
+                arity: 3,
+            },
+            TypeCtor {
+                path: string_to_path("bar::Bar"),
+                lifetime_arity: 0,
+                arity: 0,
+            },
+            TypeCtor {
+                path: string_to_path("i32"),
+                lifetime_arity: 0,
+                arity: 0,
+            },
+        ];
+
+        syn::visit::visit_type(&mut extractor, &ty);
+        let actual = extractor.unique_type_ctors();
+        check!(actual == expected);
+    }
+}

--- a/safer-ffi-gen/Cargo.toml
+++ b/safer-ffi-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safer-ffi-gen"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Tom Leavy", "Stephane Raux"]
 description = "FFI wrapper generator based on safer-ffi"
 edition = "2021"
@@ -14,7 +14,7 @@ headers = ["safer-ffi/headers", "std"]
 std = ["once_cell/std", "safer-ffi/std"]
 
 [dependencies]
-safer-ffi-gen-macro = { path = "../safer-ffi-gen-macro/", version = "0.7.0"}
+safer-ffi-gen-macro = { path = "../safer-ffi-gen-macro/", version = "0.8.0"}
 safer-ffi = { version = "0.1.0", default-features = false, features = ["alloc", "proc_macros"] }
 once_cell = { version = "1.9", default-features = false, features = ["alloc", "critical-section"] }
 

--- a/safer-ffi-gen/src/lib.rs
+++ b/safer-ffi-gen/src/lib.rs
@@ -61,6 +61,8 @@ impl_ffi_type_as_identity!(i32);
 impl_ffi_type_as_identity!(u32);
 impl_ffi_type_as_identity!(i64);
 impl_ffi_type_as_identity!(u64);
+impl_ffi_type_as_identity!(isize);
+impl_ffi_type_as_identity!(usize);
 impl_ffi_type_as_identity!(bool);
 impl_ffi_type_as_identity!(());
 

--- a/safer-ffi-gen/tests/return_lifetime.rs
+++ b/safer-ffi-gen/tests/return_lifetime.rs
@@ -1,0 +1,17 @@
+// This test checks that methods that rely on the lifetime deduction rule that links implicit
+// lifetimes in the return type to the lifetime of `self` are appropriately converted to free
+// functions (that set explicit lifetimes).
+
+use safer_ffi_gen::{ffi_type, safer_ffi_gen};
+
+#[ffi_type(opaque)]
+pub struct Foo {
+    _x: i32,
+}
+
+#[safer_ffi_gen]
+impl Foo {
+    pub fn foo(&self, _s: &str) -> &str {
+        ""
+    }
+}


### PR DESCRIPTION
- Support free functions
- Support `isize` and `usize`
- Support method inputs with multiple lifetimes
- Rework impl block support to build on top of free functions
- Support macros on methods
- Fix `Result` handling in specialization
- Define type aliases instead of `use` aliases for specialization as the latter does not support publicly exporting a public item imported as private
- Add more tests

Note that const generics are not supported.